### PR TITLE
Bugfix: Check for Metrics Route in HttpContext.

### DIFF
--- a/src/App.Metrics.Extensions.Middleware/Extensions/HttpContextExtensions.cs
+++ b/src/App.Metrics.Extensions.Middleware/Extensions/HttpContextExtensions.cs
@@ -22,11 +22,13 @@ namespace Microsoft.AspNetCore.Http
 
         public static string GetMetricsCurrentRouteName(this HttpContext context)
         {
-            var route = context.Items[MetricsCurrentRouteName] as string;
-
-            if (route.IsPresent())
+            if (context.Items.TryGetValue(MetricsCurrentRouteName, out var item))
             {
-                return context.Request.Method + " " + context.Items[MetricsCurrentRouteName];
+                var route = item as string;
+                if (route.IsPresent())
+                {
+                    return $"{context.Request.Method} {route}";
+                }
             }
 
             return context.Request.Method;


### PR DESCRIPTION
This fix addresses issue #191, adding a quick dictionary check and returning the default value if the item does not exist in the dictionary (instead of throwing a `KeyNotFoundException`).

### Details on the issue fix or feature implementation

Normally it appears AppMetrics endpoints append some custom items to the `HttpContext` dictionary items, which are then referred to later. If for some reason the dictionary items are blank, a default value is returned.

In the scenario where somehow the dictionary item is not appended in the first place, the code was throwing a `KeyNotFoundException`. With this bugfix, the code now checks for the existence of the dictionary item first, and returns the same default value if it is missing.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 