### PR TITLE
#245 Target .NET 4.5 on App.Metrics.Abstractions

### DIFF
--- a/src/App.Metrics.Abstractions/App.Metrics.Abstractions.csproj
+++ b/src/App.Metrics.Abstractions/App.Metrics.Abstractions.csproj
@@ -8,8 +8,4 @@
     <PackageTags>appmetrics;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
-    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
-  </ItemGroup>
-  
 </Project>

--- a/src/App.Metrics.Abstractions/App.Metrics.Abstractions.csproj
+++ b/src/App.Metrics.Abstractions/App.Metrics.Abstractions.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <Description>App Metrics Core abstractions and interfaces for metric types, reporting, filtering and more.</Description>
-    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <RootNamespace>App.Metrics</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>appmetrics;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
   </ItemGroup>
   

--- a/src/App.Metrics.Core/App.Metrics.Core.csproj
+++ b/src/App.Metrics.Core/App.Metrics.Core.csproj
@@ -36,4 +36,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
### The issue or feature being addressed
Issue #245.

### Details on the issue fix or feature implementation
This changes the App.Metrics.Abstractions package to target both .NET Standard and .NET Framework in order to reduce the number of dependencies installed in framework projects.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits 