### PR TITLE
Exponential decay reservoir should update sum during rescaling

### DIFF
--- a/src/App.Metrics.Core/ReservoirSampling/ExponentialDecay/DefaultForwardDecayingReservoir.cs
+++ b/src/App.Metrics.Core/ReservoirSampling/ExponentialDecay/DefaultForwardDecayingReservoir.cs
@@ -288,7 +288,7 @@ namespace App.Metrics.ReservoirSampling.ExponentialDecay
 
                 // make sure the counter is in sync with the number of stored samples.
                 _count.SetValue(_values.Count);
-                _sum.SetValue(_values.Values.Aggregate(0L, (current, sample) => current + sample.Value));
+                _sum.SetValue(_values.Values.Sum(sample => sample.Value));
             }
             finally
             {

--- a/test/App.Metrics.Sampling.Facts/ExponentiallyDecayingReservoirTests.cs
+++ b/test/App.Metrics.Sampling.Facts/ExponentiallyDecayingReservoirTests.cs
@@ -61,6 +61,7 @@ namespace App.Metrics.Sampling.Facts
             var snapshot = reservoir.GetSnapshot();
             snapshot.Size.Should().Be(2);
             snapshot.Values.Should().OnlyContain(v => v >= 1000 && v < 3000);
+            snapshot.Sum.Should().Be(snapshot.Values.Sum());
 
             // add 1000 values at a rate of 10 values/second
             for (var i = 0; i < 1000; i++)
@@ -72,6 +73,7 @@ namespace App.Metrics.Sampling.Facts
             var finalSnapshot = reservoir.GetSnapshot();
 
             finalSnapshot.Size.Should().Be(10);
+            snapshot.Sum.Should().Be(snapshot.Values.Sum());
             finalSnapshot.Values.Skip(1).Should().OnlyContain(v => v >= 3000 && v < 4000);
         }
 


### PR DESCRIPTION
### The issue or feature being addressed

https://github.com/AppMetrics/AppMetrics/issues/256

### Details on the issue fix or feature implementation

Ensured that the sum is updated during rescaling, and also added verification for it in the relevant unit test. 
Also included a couple minor performance tweaks.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 