### PR TITLE
#294 fix spelling in logs

### DIFF
--- a/src/App.Metrics.Core/Scheduling/DefaultMeterTickerScheduler.cs
+++ b/src/App.Metrics.Core/Scheduling/DefaultMeterTickerScheduler.cs
@@ -39,15 +39,15 @@ namespace App.Metrics.Scheduling
             {
                 Logger.Trace(
                     _meters.TryTake(out meter)
-                        ? "Successfully removed meter from {MeterTickScheuler} schedule."
-                        : "Failed to remove meter from {MeterTickScheuler} schedule.", this);
+                        ? "Successfully removed meter from {MeterTickScheduler} schedule."
+                        : "Failed to remove meter from {MeterTickScheduler} schedule.", this);
             }
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            Logger.Trace("Disposing {MeterTickScheuler} scheduler", this);
+            Logger.Trace("Disposing {MeterTickScheduler} scheduler", this);
 
             lock (_syncLock)
             {
@@ -61,16 +61,16 @@ namespace App.Metrics.Scheduling
 
             _scheduler.Dispose();
 
-            Logger.Trace("{MeterTickScheuler} scheduler disposed", this);
+            Logger.Trace("{MeterTickScheduler} scheduler disposed", this);
 
             Tick().GetAwaiter().GetResult();
         }
 
         private void SetScheduler()
         {
-            Logger.Trace("Starting {MeterTickScheuler} scheduler", this);
+            Logger.Trace("Starting {MeterTickScheduler} scheduler", this);
             _scheduler.Start(TickInterval);
-            Logger.Trace("{MeterTickScheuler} scheduler started", this);
+            Logger.Trace("{MeterTickScheduler} scheduler started", this);
         }
 
         private Task Tick()
@@ -89,7 +89,7 @@ namespace App.Metrics.Scheduling
 
                 if (Logger.IsDebugEnabled())
                 {
-                    Logger.Trace("{MeterCount} meters all ticked in {ElapsedTicks} ticks using {MeterTickScheuler}", _meters.Count, TickStopWatch.ElapsedTicks, this);
+                    Logger.Trace("{MeterCount} meters all ticked in {ElapsedTicks} ticks using {MeterTickScheduler}", _meters.Count, TickStopWatch.ElapsedTicks, this);
                     TickStopWatch.Reset();
                     TickStopWatch.Stop();
                 }


### PR DESCRIPTION
### The issue or feature being addressed

[294](https://github.com/AppMetrics/AppMetrics/issues/294)

### Details on the issue fix or feature implementation

Fix spelling mistake in logs in the word 'Scheduler'


### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 