### PR TITLE
LibLog - Fixed NLog + Log4net callsite. Added support for NLog structured logging

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,6 @@
     <BenchmarkDotNetVersion>0.10.14</BenchmarkDotNetVersion>
     <CoreFxVersion>4.4.0</CoreFxVersion>
     <DependencyModelVersion>2.1.1</DependencyModelVersion>
-    <LibLogVersion>5.0.0</LibLogVersion>
     <MicrosoftCSharpVersion>4.5.0</MicrosoftCSharpVersion>
     <MoqVersion>4.8.3</MoqVersion>
     <NewtonsoftVersion>11.0.2</NewtonsoftVersion>

--- a/src/App.Metrics.Core/App.Metrics.Core.csproj
+++ b/src/App.Metrics.Core/App.Metrics.Core.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <DefineConstants>$(DefineConstants);CLASSIC;LIBLOG_PORTABLE;LIBLOG_PUBLIC;THREADING_TIMER</DefineConstants>
+    <DefineConstants>$(DefineConstants);CLASSIC;LIBLOG_PUBLIC;THREADING_TIMER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/App.Metrics.Core/App.Metrics.Core.csproj
+++ b/src/App.Metrics.Core/App.Metrics.Core.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics.Concurrency" Version="$(AppMetricsConcurrencyVersion)" />
-    <PackageReference Include="LibLog" Version="$(LibLogVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### The issue or feature being addressed

Merged changes from LibLog before it was split into multiple files. See also https://github.com/damianh/LibLog/pull/145

### Details on the issue fix or feature implementation

- Removed unnecessary RegEx when using NLog
- Removed unnecessary StackTrace capture when using NLog
- Reduced memory allocations when using Log4net

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits 