### PR TITLE
#364 - Fixes MeterOptions.ReportSetItems default value.

### DIFF
--- a/src/App.Metrics.Abstractions/Meter/MeterOptions.cs
+++ b/src/App.Metrics.Abstractions/Meter/MeterOptions.cs
@@ -16,6 +16,7 @@ namespace App.Metrics.Meter
         public MeterOptions()
         {
             RateUnit = TimeUnit.Minutes;
+            ReportSetItems = true;
         }
 
         /// <summary>

--- a/test/App.Metrics.Facts/Meter/MeterOptionsTests.cs
+++ b/test/App.Metrics.Facts/Meter/MeterOptionsTests.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="MeterOptionsTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using App.Metrics.Meter;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Facts.Meter
+{
+    public class MeterOptionsTests
+    {
+        private readonly MeterOptions _meterOptions;
+
+        public MeterOptionsTests()
+        {
+            _meterOptions = new MeterOptions();
+        }
+
+        [Fact]
+        public void Has_correct_default_values()
+        {
+            _meterOptions.RateUnit.Should().Be(TimeUnit.Minutes);
+            _meterOptions.ReportSetItems.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

#364

### Details on the issue fix or feature implementation

Sets the default value of the `MeterOptions.ReportSetItems` property to `true`. This matches the XML documentation comments and the behaviour of the `CounterOptions.ReportSetItems` property.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 
