### PR TITLE
#414 reset failure attempts in case of successful call to influxdb

### DIFF
--- a/src/Reporting/src/App.Metrics.Reporting.InfluxDB/Client/DefaultLineProtocolClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.InfluxDB/Client/DefaultLineProtocolClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DefaultLineProtocolClient.cs" company="App Metrics Contributors">
+// <copyright file="DefaultLineProtocolClient.cs" company="App Metrics Contributors">
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
@@ -73,6 +73,8 @@ namespace App.Metrics.Reporting.InfluxDB.Client
 
                     return new LineProtocolWriteResult(false, errorMessage);
                 }
+
+                Interlocked.Exchange(ref _failureAttempts, 0);
 
                 Logger.Trace("Successful write to InfluxDB");
 

--- a/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/DefaultLineProtocolClientTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/DefaultLineProtocolClientTests.cs
@@ -228,6 +228,44 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
         }
 
         [Fact]
+        public async Task Should_reset_failure_attempts_in_case_of_success_request()
+        {
+            // Arrange
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            int callCount = 0;
+            httpMessageHandlerMock.Protected().Setup<Task<HttpResponseMessage>>(
+                                       "SendAsync",
+                                       ItExpr.IsAny<HttpRequestMessage>(),
+                                       ItExpr.IsAny<CancellationToken>()).
+                                   ReturnsAsync(
+                                       () => ++callCount % 2 == 0
+                                           ? new HttpResponseMessage(HttpStatusCode.BadRequest)
+                                           : new HttpResponseMessage(HttpStatusCode.OK));
+            var policy = new HttpPolicy { FailuresBeforeBackoff = 3, BackoffPeriod = TimeSpan.FromMinutes(1) };
+            var settings = new InfluxDbOptions
+                           {
+                               BaseUri = new Uri("http://localhost"),
+                               Database = "influx"
+                           };
+            var influxClient = MetricsInfluxDbReporterBuilder.CreateClient(settings, policy, httpMessageHandlerMock.Object);
+
+            // Act
+            foreach (var attempt in Enumerable.Range(0, 10))
+            {
+                using (var payload = new MemoryStream(Encoding.UTF8.GetBytes(Payload)))
+                {
+                    await influxClient.WriteAsync(payload, CancellationToken.None);
+                }
+
+                httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    Times.Exactly(attempt + 1),
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+        }
+        
+        [Fact]
         public async Task Can_create_database_without_retention_policy()
         {
             // Arrange


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/alhardy/AppMetrics/blob/master/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- #414 

### Details on the issue fix or feature implementation

- Reset `_failureAttempts` variable when `response.IsSuccessStatusCode`

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 
