### PR TITLE
tests for disabled synchronous IO

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test", "benchmarks", "sandbox" ],
   "sdk": {
-    "version": "2.2.101"
+    "version": "3.0.100-preview5-011568"
   }
 }

--- a/src/Core/AppMetrics.sln
+++ b/src/Core/AppMetrics.sln
@@ -50,6 +50,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.FactsCommon", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsSandbox", "sandbox\MetricsSandbox\MetricsSandbox.csproj", "{BB634992-7DF4-44AE-8D36-1C6AF3F9A9BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.AspNetCore.AsynchronousReporting.Facts", "test\App.Metrics.AspNetCore.AsynchronousReporting.Facts\App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj", "{8314633B-7AD8-49D4-80A7-BDB473BB7B23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{BB634992-7DF4-44AE-8D36-1C6AF3F9A9BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB634992-7DF4-44AE-8D36-1C6AF3F9A9BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB634992-7DF4-44AE-8D36-1C6AF3F9A9BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8314633B-7AD8-49D4-80A7-BDB473BB7B23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8314633B-7AD8-49D4-80A7-BDB473BB7B23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8314633B-7AD8-49D4-80A7-BDB473BB7B23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8314633B-7AD8-49D4-80A7-BDB473BB7B23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,6 +133,7 @@ Global
 		{20493337-3B29-4152-B704-F60B3B3DEF63} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
 		{B6C5532F-EFCC-4FA4-8249-A0B18060955F} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
 		{BB634992-7DF4-44AE-8D36-1C6AF3F9A9BE} = {C0BC96C5-46E1-4323-9C5D-58D9A96549CD}
+		{8314633B-7AD8-49D4-80A7-BDB473BB7B23} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8699A1D-0BA1-403C-86E9-C789CD2645EB}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0-preview5-19227-01" />
+        <PackageReference Include="App.Metrics.AspNetCore.Endpoints" Version="3.2.0-dev0002" />
+        <PackageReference Include="App.Metrics.AspNetCore.Tracking" Version="3.2.0-dev0002" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\App.Metrics.Abstractions\App.Metrics.Abstractions.csproj" />
+      <ProjectReference Include="..\..\src\App.Metrics.Core\App.Metrics.Core.csproj" />
+      <ProjectReference Include="..\..\src\App.Metrics.Formatters.Ascii\App.Metrics.Formatters.Ascii.csproj" />
+      <ProjectReference Include="..\..\src\App.Metrics.Formatters.Json\App.Metrics.Formatters.Json.csproj" />
+    </ItemGroup>
+    
+</Project>

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/CustomWebApplicationFactory.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/CustomWebApplicationFactory.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    public class CustomWebApplicationFactory<TStartup>
+        : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        public CustomWebApplicationFactory()
+        {
+            Server.AllowSynchronousIO = false;
+        }
+        
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            return Host.CreateDefaultBuilder().ConfigureWebHost(webHost => webHost.UseStartup<TStartup>());
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/MetricsEndpointMiddlewareTests.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/MetricsEndpointMiddlewareTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Threading.Tasks;
+using App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    public class MetricsEndpointMiddlewareTests : IClassFixture<CustomWebApplicationFactory<PlainTextTestStartup>>,
+        IClassFixture<CustomWebApplicationFactory<JsonTestStartup>>
+    {
+        private readonly WebApplicationFactory<PlainTextTestStartup> _plainText;
+        private readonly WebApplicationFactory<JsonTestStartup> _json;
+
+        public MetricsEndpointMiddlewareTests(
+            CustomWebApplicationFactory<PlainTextTestStartup> plainText,
+            CustomWebApplicationFactory<JsonTestStartup> json)
+        {
+            _plainText = plainText;
+            _json = json;
+        }
+
+        [Fact]
+        public async Task PlainText_metrics_endpoint_no_exceptions()
+        {
+            // Arrange
+            var client = _plainText.CreateClient();
+
+            // Act
+            var result = await client.GetAsync("/metrics");
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Json_metrics_endpoint_no_exceptions()
+        {
+            // Arrange
+            var client = _json.CreateClient();
+
+            // Act
+            var result = await client.GetAsync("/metrics");
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/DefaultTestStartup.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/DefaultTestStartup.cs
@@ -1,0 +1,56 @@
+using System;
+using App.Metrics.Infrastructure;
+using App.Metrics.Internal.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    public abstract class DefaultTestStartup
+    {
+        private readonly Action<IMetricsOutputFormattingBuilder> _outputMetricsConfigure;
+
+        protected DefaultTestStartup(Action<IMetricsOutputFormattingBuilder> outputMetricsConfigure)
+        {
+            _outputMetricsConfigure = outputMetricsConfigure ?? throw new ArgumentNullException(nameof(outputMetricsConfigure));
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRouting(options => { options.LowercaseUrls = true; });
+            services.AddControllers();
+            
+            var builder = new MetricsBuilder();
+            _outputMetricsConfigure(builder.OutputMetrics);
+
+            var metrics = builder.Build();
+            services.TryAddSingleton(metrics.Clock);
+            services.TryAddSingleton(metrics.Filter);
+            services.TryAddSingleton(metrics.DefaultOutputMetricsFormatter);
+            services.TryAddSingleton(metrics.OutputMetricsFormatters);
+            services.TryAddSingleton(metrics.DefaultOutputEnvFormatter);
+            services.TryAddSingleton(metrics.OutputEnvFormatters);
+            services.TryAddSingleton(new EnvironmentInfoProvider());
+            services.TryAddSingleton((IMetrics) metrics);
+            services.TryAddSingleton(metrics);
+            services.TryAddSingleton(metrics.Options);
+            services.TryAddSingleton(metrics.Reporters);
+            services.TryAddSingleton(metrics.ReportRunner);
+            services.TryAddSingleton<AppMetricsMarkerService, AppMetricsMarkerService>();
+            
+            services.AddMetricsEndpoints();
+        }
+        
+        // ReSharper disable UnusedMember.Global
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+            // ReSharper restore UnusedMember.Global
+        {
+            app.UseRouting();
+            app.UseMetricsEndpoint();
+            app.UseMetricsAllMiddleware();
+        }
+    } 
+}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/JsonTestStartup.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/JsonTestStartup.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    public class JsonTestStartup : DefaultTestStartup
+    {
+        public JsonTestStartup() : base(builder => builder.AsJson())
+        {
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PlainTextTestStartup.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PlainTextTestStartup.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    // ReSharper disable ClassNeverInstantiated.Global
+    public class PlainTextTestStartup : DefaultTestStartup
+        // ReSharper restore ClassNeverInstantiated.Global
+    {
+        /// <inheritdoc />
+        public PlainTextTestStartup() : base(builder => builder.AsPlainText()) { }
+    }
+}

--- a/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/TestController.cs
+++ b/src/Core/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/TestController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    [Route("api/[controller]")]
+    public class TestController : ControllerBase
+    {
+        private readonly IMetrics _metrics;
+
+        public TestController(IMetrics metrics) { _metrics = metrics; }
+        
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok();
+        }
+    }
+}

--- a/src/Reporting/Reporting.sln
+++ b/src/Reporting/Reporting.sln
@@ -104,6 +104,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsPrometheusSandbox", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsPrometheusSandboxMvc", "sandbox\MetricsPrometheusSandboxMvc\MetricsPrometheusSandboxMvc.csproj", "{70F9BB97-02A0-42CC-9C84-BF1FB588A7DE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.AspNetCore.AsynchronousReporting.Facts", "test\App.Metrics.AspNetCore.AsynchronousReporting.Facts\App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj", "{C9816A50-FF5C-445B-A2D2-27DB095A2601}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -226,6 +228,10 @@ Global
 		{70F9BB97-02A0-42CC-9C84-BF1FB588A7DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70F9BB97-02A0-42CC-9C84-BF1FB588A7DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70F9BB97-02A0-42CC-9C84-BF1FB588A7DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9816A50-FF5C-445B-A2D2-27DB095A2601}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9816A50-FF5C-445B-A2D2-27DB095A2601}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9816A50-FF5C-445B-A2D2-27DB095A2601}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9816A50-FF5C-445B-A2D2-27DB095A2601}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -273,6 +279,7 @@ Global
 		{E7D3272E-D834-4675-B4E5-9DE322864042} = {9D00C681-A88C-450E-B83E-E3BFF942F82A}
 		{B5A96731-39FB-4747-9A84-311D2CDFAA8E} = {276CABDF-9E9B-49D6-A3DD-99C9478C59C4}
 		{70F9BB97-02A0-42CC-9C84-BF1FB588A7DE} = {276CABDF-9E9B-49D6-A3DD-99C9478C59C4}
+		{C9816A50-FF5C-445B-A2D2-27DB095A2601} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {492C97B1-706A-4357-B3F7-EFB6AFB1F6C6}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/App.Metrics.AspNetCore.AsynchronousReporting.Facts.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0-preview5-19227-01" />
+        <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.2.0-dev0002" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\App.Metrics.Formatters.Prometheus\App.Metrics.Formatters.Prometheus.csproj" />
+    </ItemGroup>
+    
+</Project>

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/CustomWebApplicationFactory.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/CustomWebApplicationFactory.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    public class CustomWebApplicationFactory<TStartup>
+        : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        public CustomWebApplicationFactory()
+        {
+            Server.AllowSynchronousIO = false;
+        }
+        
+        protected override IHostBuilder CreateHostBuilder()
+        {
+            return Host.CreateDefaultBuilder().ConfigureWebHost(webHost => webHost.UseStartup<TStartup>());
+        }
+    }
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/MetricsEndpointMiddlewareTests.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/MetricsEndpointMiddlewareTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using System.Threading.Tasks;
+using App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    public class MetricsEndpointMiddlewareTests : IClassFixture<CustomWebApplicationFactory<PlainTextTestStartup>>,
+        IClassFixture<CustomWebApplicationFactory<JsonTestStartup>>,
+        IClassFixture<CustomWebApplicationFactory<PrometheusTestStartup>>
+    {
+        private readonly WebApplicationFactory<PlainTextTestStartup> _plainText;
+        private readonly WebApplicationFactory<JsonTestStartup> _json;
+        private readonly WebApplicationFactory<PrometheusTestStartup> _prometheus;
+
+        public MetricsEndpointMiddlewareTests(
+            CustomWebApplicationFactory<PlainTextTestStartup> plainText,
+            CustomWebApplicationFactory<JsonTestStartup> json,
+            CustomWebApplicationFactory<PrometheusTestStartup> prometheus)
+        {
+            _plainText = plainText;
+            _json = json;
+            _prometheus = prometheus;
+        }
+
+        [Fact]
+        public async Task PlainText_metrics_endpoint_no_exceptions()
+        {
+            // Arrange
+            var client = _plainText.CreateClient();
+
+            // Act
+            var result = await client.GetAsync("/metrics");
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Json_metrics_endpoint_no_exceptions()
+        {
+            // Arrange
+            var client = _json.CreateClient();
+
+            // Act
+            var result = await client.GetAsync("/metrics");
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        
+        [Fact]
+        public async Task Prometheus_metrics_endpoint_no_exceptions()
+        {
+            // Arrange
+            var client = _prometheus.CreateClient();
+
+            var response = await client.GetAsync("/test");
+            
+            // Act
+            var result = await client.GetAsync("/metrics");
+
+            // Assert
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/DefaultTestStartup.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/DefaultTestStartup.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    public abstract class DefaultTestStartup
+    {
+        private readonly Action<IMetricsOutputFormattingBuilder> _outputMetricsConfigure;
+
+        protected DefaultTestStartup(Action<IMetricsOutputFormattingBuilder> outputMetricsConfigure)
+        {
+            _outputMetricsConfigure = outputMetricsConfigure ?? throw new ArgumentNullException(nameof(outputMetricsConfigure));
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRouting(options => { options.LowercaseUrls = true; });
+            services.AddControllers();
+            
+            var builder = new MetricsBuilder();
+            _outputMetricsConfigure(builder.OutputMetrics);
+
+            services.AddMetrics(builder);
+            services.AddMetricsEndpoints();
+        }
+        
+        // ReSharper disable UnusedMember.Global
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+            // ReSharper restore UnusedMember.Global
+        {
+            app.UseRouting();
+            app.UseMetricsEndpoint();
+            app.UseMetricsAllMiddleware();
+        }
+    } 
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/JsonTestStartup.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/JsonTestStartup.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    public class JsonTestStartup : DefaultTestStartup
+    {
+        public JsonTestStartup() : base(builder => builder.AsJson())
+        {
+        }
+    }
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PlainTextTestStartup.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PlainTextTestStartup.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    // ReSharper disable ClassNeverInstantiated.Global
+    public class PlainTextTestStartup : DefaultTestStartup
+        // ReSharper restore ClassNeverInstantiated.Global
+    {
+        /// <inheritdoc />
+        public PlainTextTestStartup() : base(builder => builder.AsPlainText()) { }
+    }
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PrometheusTestStartup.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/Startup/PrometheusTestStartup.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts.Startup
+{
+    public class PrometheusTestStartup : DefaultTestStartup
+    {
+        public PrometheusTestStartup() : base(builder => builder.AsPrometheusPlainText()) { }
+    }
+}

--- a/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/TestController.cs
+++ b/src/Reporting/test/App.Metrics.AspNetCore.AsynchronousReporting.Facts/TestController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Metrics.AspNetCore.AsynchronousReporting.Facts
+{
+    [Route("api/[controller]")]
+    public class TestController : ControllerBase
+    {
+        private readonly IMetrics _metrics;
+
+        public TestController(IMetrics metrics) { _metrics = metrics; }
+        
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
Hey, @alhardy. This is draft pull request with tests for disabled synchronous IO (#396). All of tests are failed with the `System.InvalidOperationException : Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true.`. However, before beginning to solve problems I suggest to do the following changes in App.Metrics code base:

1. Create separate solution with integrations tests. Right now, if we want to test prometheus, plain text and json output formatters in Asp.Net Core application, it needed to create two test projects: the first one in `Reporting` solution, the second one in `Core` solution. In addition, some references need to be installed from nuget package, what could be the problem to reproduce another issue with integration App.Metrics components. And finally, it's allow to use .net core 3.0 only in this solution. .Net Core 3.0 is required for test cases with disabled synchronous IO due to `AllowSynchronousIO` will be added in TestServer of 3.0 version.
2. Update CI to .net core 3.0 due to .net core will be released in half of year and App.Metrics need to be started to test integration with .net core 3.0 (the amount of issues related to .net core 3.0 is increased).

What do you think about it? If you align with my thoughts, I will be very appreciate to start this work.