### PR TITLE
added auth header options

### DIFF
--- a/src/Reporting/src/App.Metrics.Reporting.Http/Client/DefaultHttpClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Http/Client/DefaultHttpClient.cs
@@ -106,7 +106,7 @@ namespace App.Metrics.Reporting.Http.Client
             {
                 client.BaseAddress = httpSettings.RequestUri;
                 client.Timeout = httpPolicy.Timeout;
-                client.DefaultRequestHeaders.Add("Authorization", httpSettings.AuthorizationToken);
+                client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(httpSettings.AuthorizationToken);
                 return client;
             }
 

--- a/src/Reporting/src/App.Metrics.Reporting.Http/Client/DefaultHttpClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Http/Client/DefaultHttpClient.cs
@@ -92,15 +92,23 @@ namespace App.Metrics.Reporting.Http.Client
             client.BaseAddress = httpSettings.RequestUri;
             client.Timeout = httpPolicy.Timeout;
 
-            if (string.IsNullOrWhiteSpace(httpSettings.UserName) || string.IsNullOrWhiteSpace(httpSettings.Password))
+            if (!string.IsNullOrWhiteSpace(httpSettings.UserName) && !string.IsNullOrWhiteSpace(httpSettings.Password))
             {
+
+                var byteArray = Encoding.ASCII.GetBytes($"{httpSettings.UserName}:{httpSettings.Password}");
+                client.BaseAddress = httpSettings.RequestUri;
+                client.Timeout = httpPolicy.Timeout;
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
                 return client;
             }
 
-            var byteArray = Encoding.ASCII.GetBytes($"{httpSettings.UserName}:{httpSettings.Password}");
-            client.BaseAddress = httpSettings.RequestUri;
-            client.Timeout = httpPolicy.Timeout;
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+            if (!string.IsNullOrWhiteSpace(httpSettings.AuthorizationToken))
+            {
+                client.BaseAddress = httpSettings.RequestUri;
+                client.Timeout = httpPolicy.Timeout;
+                client.DefaultRequestHeaders.Add("Authorization", httpSettings.AuthorizationToken);
+                return client;
+            }
 
             return client;
         }

--- a/src/Reporting/src/App.Metrics.Reporting.Http/Client/HttpSettings.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Http/Client/HttpSettings.cs
@@ -35,5 +35,10 @@ namespace App.Metrics.Reporting.Http.Client
         ///     The basic auth username.
         /// </value>
         public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authorization to use for the request
+        /// </summary>
+        public string AuthorizationToken { get; set; }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.Http.Facts/MetricsHttpReporterBuilderTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.Http.Facts/MetricsHttpReporterBuilderTests.cs
@@ -216,5 +216,27 @@ namespace App.Metrics.Reporting.Http.Facts
             // Assert
             action.Should().Throw<ArgumentNullException>();
         }
+
+        [Fact]
+        public void Can_use_http_reporter_with_authorization_token()
+        {
+            // Arrange
+            var builder = new MetricsBuilder().Report.OverHttp(
+                options =>
+                {
+                    options.HttpSettings.AuthorizationToken = "test";
+                    options.HttpSettings.RequestUri = new Uri("http://localhost");
+                    options.MetricsOutputFormatter = new MetricsJsonOutputFormatter();
+                });
+
+            // Act
+            var metrics = builder.Build();
+
+            // Assert
+            metrics.Reporters.Should().Contain(reportMetrics => reportMetrics is HttpMetricsReporter);
+            metrics.Reporters.First().FlushInterval.Should().Be(AppMetricsConstants.Reporting.DefaultFlushInterval);
+            metrics.Reporters.First().Filter.Should().BeOfType<NullMetricsFilter>();
+            metrics.Reporters.First().Formatter.Should().BeOfType<MetricsJsonOutputFormatter>();
+        }
     }
 }


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/master/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

https://github.com/AppMetrics/AppMetrics/issues/455

### Details on the issue fix or feature implementation

- I have a case where i am reporting metrics via http/https which we have secured with JWT auth (Authorization header with token value). There doesn't seem to be a way to attach a token with header to the http object, as it relates to app metrics. What i've done is this exact op.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
