### PR TITLE
Add bucket histograms

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AppMetricsConcurrencyVersion>2.0.1</AppMetricsConcurrencyVersion>
-    <AppMetricsVersion>3.2.0-bucket-histograms*</AppMetricsVersion>
+    <AppMetricsVersion>3.1.0-*</AppMetricsVersion>
     <FrameworkVersion>2.1.0</FrameworkVersion>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AppMetricsConcurrencyVersion>2.0.1</AppMetricsConcurrencyVersion>
-    <AppMetricsVersion>3.1.0-*</AppMetricsVersion>
+    <AppMetricsVersion>3.2.0-bucket-histograms*</AppMetricsVersion>
     <FrameworkVersion>2.1.0</FrameworkVersion>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AppMetricsConcurrencyVersion>2.0.1</AppMetricsConcurrencyVersion>
-    <AppMetricsVersion>3.1.0-*</AppMetricsVersion>
+    <AppMetricsVersion>3.2.0-*</AppMetricsVersion>
     <FrameworkVersion>2.1.0</FrameworkVersion>
   </PropertyGroup>
 

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
@@ -126,10 +126,12 @@ namespace App.Metrics
         /// <param name="metrics">The metrics.</param>
         /// <param name="routeTemplate">The route template of the endpoint.</param>
         /// <param name="httpStatusCode">The HTTP status code.</param>
+        /// <param name="bucketTimerOptions">The Bucket Timer options.</param>
         public static void RecordHttpRequestError(
             this IMetrics metrics,
             string routeTemplate,
-            int httpStatusCode)
+            int httpStatusCode, 
+            BucketTimerOptions bucketTimerOptions)
         {
             CountOverallErrorRequestsByHttpStatusCode(metrics, httpStatusCode);
 
@@ -137,7 +139,7 @@ namespace App.Metrics
 
             RecordEndpointsHttpRequestErrors(metrics, routeTemplate, httpStatusCode);
             RecordOverallPercentageOfErrorRequests(metrics);
-            RecordEndpointsPercentageOfErrorRequests(metrics, routeTemplate);
+            RecordEndpointsPercentageOfErrorRequests(metrics, routeTemplate, bucketTimerOptions);
         }
 
         /// <summary>
@@ -266,12 +268,12 @@ namespace App.Metrics
                 endpointErrorRequestPerStatusCodeTags);
         }
 
-        private static void RecordEndpointsPercentageOfErrorRequests(IMetrics metrics, string routeTemplate)
+        private static void RecordEndpointsPercentageOfErrorRequests(IMetrics metrics, string routeTemplate, BucketTimerOptions bucketTimerOptions)
         {
             var tags = new MetricTags(MiddlewareConstants.DefaultTagKeys.Route, routeTemplate);
 
             var endpointsErrorRate = metrics.Provider.Meter.Instance(HttpRequestMetricsRegistry.Meters.EndpointErrorRequestRate, tags);
-            var endpointsRequestTransactionTime = metrics.EndpointRequestTimer(routeTemplate, null);
+            var endpointsRequestTransactionTime = metrics.EndpointRequestTimer(routeTemplate, bucketTimerOptions);
 
             metrics.Measure.Gauge.SetValue(
                 HttpRequestMetricsRegistry.Gauges.EndpointOneMinuteErrorPercentageRate,

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using App.Metrics.AspNetCore.Internal;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Gauge;
 using App.Metrics.Timer;
 
@@ -164,6 +165,56 @@ namespace App.Metrics
         public static void UpdatePutRequestSize(this IMetrics metrics, long value)
         {
             metrics.Measure.Histogram.Update(HttpRequestMetricsRegistry.Histograms.PutRequestSizeHistogram, value);
+        }
+
+        /// <summary>
+        ///     Records a metric for the size of a HTTP POST requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        /// <param name="bucketHistogramOptions">The bucket histogram options</param>
+        /// <param name="value">The value.</param>
+        /// <param name="clientId">The OAuth2 client identifier.</param>
+        /// <param name="routeTemplate">The route template of the endpoint.</param>
+        public static void UpdateClientPostRequestSize(this IMetrics metrics, BucketHistogramOptions bucketHistogramOptions, long value, string clientId, string routeTemplate)
+        {
+            var tags = new MetricTags(new[] { MiddlewareConstants.DefaultTagKeys.ClientId, MiddlewareConstants.DefaultTagKeys.Route }, new[] { clientId, routeTemplate });
+            metrics.Measure.BucketHistogram.Update(bucketHistogramOptions, tags, value);
+        }
+
+        /// <summary>
+        ///     Records a metric for the size of a HTTP PUT requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        /// <param name="bucketHistogramOptions">The bucket histogram options</param>
+        /// <param name="value">The value.</param>
+        /// <param name="clientId">The OAuth2 client identifier to tag the histogram values.</param>
+        /// <param name="routeTemplate">The route template of the endpoint.</param>
+        public static void UpdateClientPutRequestSize(this IMetrics metrics, BucketHistogramOptions bucketHistogramOptions, long value, string clientId, string routeTemplate)
+        {
+            var tags = new MetricTags(new[] { MiddlewareConstants.DefaultTagKeys.ClientId, MiddlewareConstants.DefaultTagKeys.Route }, new[] { clientId, routeTemplate });
+            metrics.Measure.BucketHistogram.Update(bucketHistogramOptions, tags, value);
+        }
+
+        /// <summary>
+        ///     Records a metric for the size of a HTTP POST requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        /// <param name="bucketHistogramOptions">The bucket histogram options</param>
+        /// <param name="value">The value.</param>
+        public static void UpdatePostRequestSize(this IMetrics metrics, BucketHistogramOptions bucketHistogramOptions, long value)
+        {
+            metrics.Measure.BucketHistogram.Update(bucketHistogramOptions, value);
+        }
+
+        /// <summary>
+        ///     Records a metric for the size of a HTTP PUT requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        /// <param name="bucketHistogramOptions">The bucket histogram options</param>
+        /// <param name="value">The value.</param>
+        public static void UpdatePutRequestSize(this IMetrics metrics, BucketHistogramOptions bucketHistogramOptions, long value)
+        {
+            metrics.Measure.BucketHistogram.Update(bucketHistogramOptions, value);
         }
 
         private static void CountOverallErrorRequestsByHttpStatusCode(IMetrics metrics, int httpStatusCode)

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -90,6 +91,25 @@ namespace App.Metrics.AspNetCore.Internal
                                                                                   Context = ContextName,
                                                                                   Name = "PUT Size",
                                                                                   MeasurementUnit = Unit.Bytes
+                                                                              };
+        }
+
+        public static class BucketHistograms
+        {
+            public static readonly Func<double[], BucketHistogramOptions> PostRequestSizeHistogram = buckets => new BucketHistogramOptions
+            {
+                                                                                   Context = ContextName,
+                                                                                   Name = "POST Size",
+                                                                                   MeasurementUnit = Unit.Bytes,
+                                                                                   Buckets = buckets
+                                                                               };
+
+            public static readonly Func<double[], BucketHistogramOptions> PutRequestSizeHistogram = buckets => new BucketHistogramOptions
+            {
+                                                                                  Context = ContextName,
+                                                                                  Name = "PUT Size",
+                                                                                  MeasurementUnit = Unit.Bytes,
+                                                                                  Buckets = buckets
                                                                               };
         }
 

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -151,6 +152,25 @@ namespace App.Metrics.AspNetCore.Internal
                                                                                  Context = ContextName,
                                                                                  Name = "Transactions",
                                                                                  MeasurementUnit = Unit.Requests
+                                                                             };
+        }
+
+        public static class BucketTimers
+        {
+            public static readonly Func<double[], BucketTimerOptions> EndpointRequestTransactionDuration = buckets => new BucketTimerOptions
+                                                                                     {
+                                                                                         Context = ContextName,
+                                                                                         Name = "Transactions Per Endpoint",
+                                                                                         MeasurementUnit = Unit.Requests,
+                                                                                         Buckets = buckets
+                                                                                     };
+
+            public static readonly Func<double[], BucketTimerOptions> RequestTransactionDuration = buckets => new BucketTimerOptions
+                                                                             {
+                                                                                 Context = ContextName,
+                                                                                 Name = "Transactions",
+                                                                                 MeasurementUnit = Unit.Requests,
+                                                                                 Buckets = buckets
                                                                              };
         }
     }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/OAuthRequestMetricsRegistry.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/OAuthRequestMetricsRegistry.cs
@@ -2,7 +2,9 @@
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Diagnostics.CodeAnalysis;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
 
@@ -45,6 +47,25 @@ namespace App.Metrics.AspNetCore.Internal
                                                                                    Context = ContextName,
                                                                                    Name = "POST Size",
                                                                                    MeasurementUnit = Unit.Bytes
+                                                                               };
+        }
+
+        public static class BucketHistograms
+        {
+            public static readonly Func<double[], BucketHistogramOptions> PutRequestSizeHistogram = buckets => new BucketHistogramOptions
+            {
+                                                                                  Context = ContextName,
+                                                                                  Name = "PUT Size",
+                                                                                  MeasurementUnit = Unit.Bytes,
+                                                                                  Buckets = buckets
+                                                                              };
+
+            public static readonly Func<double[], BucketHistogramOptions> PostRequestSizeHistogram = buckets => new BucketHistogramOptions
+            {
+                                                                                   Context = ContextName,
+                                                                                   Name = "POST Size",
+                                                                                   MeasurementUnit = Unit.Bytes,
+                                                                                   Buckets = buckets
                                                                                };
         }
     }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
@@ -78,5 +78,23 @@ namespace App.Metrics.AspNetCore.Tracking
         ///     <c>true</c> if [o auth2 tracking enabled]; otherwise, <c>false</c>.
         /// </value>
         public bool OAuth2TrackingEnabled { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether [bucket histograms should be used], if disabled histograms will be used.
+        /// </summary>
+        /// <value>
+        ///     <c>true</c> if [bucket histograms should be used]; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseBucketHistograms { get; set; }
+
+
+        /// <summary>
+        ///     Gets or sets the buckets to use from bucket histograms
+        /// </summary>
+        /// <remarks>Only valid if UseBucketHistograms is true.</remarks>
+        /// <value>
+        ///     Array of buckets
+        /// </value>
+        public double[] RequestSizeHistogramBuckets { get; set; }
     }
 }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/MetricsWebTrackingOptions.cs
@@ -89,12 +89,22 @@ namespace App.Metrics.AspNetCore.Tracking
 
 
         /// <summary>
-        ///     Gets or sets the buckets to use from bucket histograms
+        ///     Gets or sets the buckets to use for request size bucket histograms
         /// </summary>
         /// <remarks>Only valid if UseBucketHistograms is true.</remarks>
         /// <value>
         ///     Array of buckets
         /// </value>
         public double[] RequestSizeHistogramBuckets { get; set; }
+
+
+        /// <summary>
+        ///     Gets or sets the buckets to use for request time bucket timer
+        /// </summary>
+        /// <remarks>Only valid if UseBucketHistograms is true.</remarks>
+        /// <value>
+        ///     Array of buckets
+        /// </value>
+        public double[] RequestTimeHistogramBuckets { get; set; }
     }
 }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
@@ -8,6 +8,7 @@ using App.Metrics.AspNetCore.Internal;
 using App.Metrics.Timer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace App.Metrics.AspNetCore.Tracking.Middleware
 {
@@ -22,14 +23,20 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
 
         public RequestTimerMiddleware(
             RequestDelegate next,
+            IOptions<MetricsWebTrackingOptions> trackingMiddlwareOptionsAccessor,
             ILogger<RequestTimerMiddleware> logger,
             IMetrics metrics)
         {
             _logger = logger;
             _next = next ?? throw new ArgumentNullException(nameof(next));
-            _requestTimer = metrics.Provider
-                                   .Timer
-                                   .Instance(HttpRequestMetricsRegistry.Timers.RequestTransactionDuration);
+            if (trackingMiddlwareOptionsAccessor.Value.UseBucketHistograms)
+            {
+                _requestTimer = metrics.Provider.BucketTimer.Instance(HttpRequestMetricsRegistry.BucketTimers.RequestTransactionDuration(trackingMiddlwareOptionsAccessor.Value.RequestTimeHistogramBuckets));
+            }
+            else
+            {
+                _requestTimer = metrics.Provider.Timer.Instance(HttpRequestMetricsRegistry.Timers.RequestTransactionDuration);
+            }
         }
 
         // ReSharper disable UnusedMember.Global

--- a/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
+++ b/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
@@ -47,7 +47,7 @@ namespace MetricsSandbox
         public static BucketHistogramOptions BucketHistogramOne => new BucketHistogramOptions
                                                                     {
                                                                         Name = "bucket_histogram_one",
-                                                                        Buckets = new []{10L,50L,100L}
+                                                                        Buckets = new []{10d,50d,100d}
                                                                     };
 
         public static MeterOptions MeterOne => new MeterOptions

--- a/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
+++ b/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
@@ -4,6 +4,7 @@
 
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -65,5 +66,10 @@ namespace MetricsSandbox
                                                {
                                                    Name = "timer_one"
                                                };
+
+        public static BucketTimerOptions BucketTimerOne => new BucketTimerOptions
+        {
+            Name = "timer_one"
+        };
     }
 }

--- a/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
+++ b/src/Core/sandbox/MetricsSandbox/ApplicationsMetricsRegistry.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -42,6 +43,12 @@ namespace MetricsSandbox
                                                        {
                                                            Name = "histogram_one"
                                                        };
+
+        public static BucketHistogramOptions BucketHistogramOne => new BucketHistogramOptions
+                                                                    {
+                                                                        Name = "bucket_histogram_one",
+                                                                        Buckets = new []{10L,50L,100L}
+                                                                    };
 
         public static MeterOptions MeterOne => new MeterOptions
                                                {

--- a/src/Core/sandbox/MetricsSandbox/Program.cs
+++ b/src/Core/sandbox/MetricsSandbox/Program.cs
@@ -107,6 +107,7 @@ namespace MetricsSandbox
                 Metrics.Measure.Counter.Increment(ApplicationsMetricsRegistry.CounterWithSetItems, "item1");
                 Metrics.Measure.Gauge.SetValue(ApplicationsMetricsRegistry.GaugeOne, Rnd.Next(0, 100));
                 Metrics.Measure.Histogram.Update(ApplicationsMetricsRegistry.HistogramOne, Rnd.Next(0, 100));
+                Metrics.Measure.BucketHistogram.Update(ApplicationsMetricsRegistry.BucketHistogramOne, Rnd.Next(0, 100));
                 Metrics.Measure.Meter.Mark(ApplicationsMetricsRegistry.MeterOne, Rnd.Next(0, 100));
                 Metrics.Measure.Meter.Mark(ApplicationsMetricsRegistry.MeterWithSetItems, Rnd.Next(0, 100), "item1");
             }

--- a/src/Core/sandbox/MetricsSandbox/RecordAndReportHostedService.cs
+++ b/src/Core/sandbox/MetricsSandbox/RecordAndReportHostedService.cs
@@ -58,6 +58,7 @@ namespace MetricsSandbox
             _metrics.Measure.Counter.Increment(ApplicationsMetricsRegistry.CounterWithSetItems, "item1");
             _metrics.Measure.Gauge.SetValue(ApplicationsMetricsRegistry.GaugeOne, Rnd.Next(0, 100));
             _metrics.Measure.Histogram.Update(ApplicationsMetricsRegistry.HistogramOne, Rnd.Next(0, 100));
+            _metrics.Measure.BucketHistogram.Update(ApplicationsMetricsRegistry.BucketHistogramOne, Rnd.Next(0, 100));
             _metrics.Measure.Meter.Mark(ApplicationsMetricsRegistry.MeterOne, Rnd.Next(0, 100));
             _metrics.Measure.Meter.Mark(ApplicationsMetricsRegistry.MeterWithSetItems, Rnd.Next(0, 100), "item1");
 

--- a/src/Core/sandbox/MetricsSandbox/RecordAndReportHostedService.cs
+++ b/src/Core/sandbox/MetricsSandbox/RecordAndReportHostedService.cs
@@ -67,6 +67,11 @@ namespace MetricsSandbox
                 Thread.Sleep(Rnd.Next(0, 100));
             }
 
+            using (_metrics.Measure.BucketTimer.Time(ApplicationsMetricsRegistry.BucketTimerOne))
+            {
+                Thread.Sleep(Rnd.Next(0, 100));
+            }
+
             using (_metrics.Measure.Apdex.Track(ApplicationsMetricsRegistry.ApdexOne))
             {
                 Thread.Sleep(Rnd.Next(0, 100));

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramOptions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramOptions.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="HistogramOptions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     Configuration of an <see cref="IBucketHistogramMetric" /> that will be measured
+    /// </summary>
+    /// <seealso cref="MetricValueOptionsBase" />
+    public class BucketHistogramOptions : MetricValueOptionsBase
+    {
+        public IEnumerable<long> Buckets { get; set; }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramOptions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramOptions.cs
@@ -12,6 +12,6 @@ namespace App.Metrics.BucketHistogram
     /// <seealso cref="MetricValueOptionsBase" />
     public class BucketHistogramOptions : MetricValueOptionsBase
     {
-        public IEnumerable<long> Buckets { get; set; }
+        public IEnumerable<double> Buckets { get; set; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="HistogramValue.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     The value reported by a Histogram Metric
+    /// </summary>
+    public sealed class BucketHistogramValue
+    {
+        public BucketHistogramValue(
+            long count,
+            double sum,
+            IReadOnlyDictionary<long, long> buckets)
+        {
+            Count = count;
+            Sum = sum;
+            Buckets = buckets;
+        }
+
+        public long Count { get; }
+
+        public double Sum { get; }
+
+        public IReadOnlyDictionary<long, long> Buckets { get; }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
@@ -2,7 +2,10 @@
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using App.Metrics.Histogram;
 
 namespace App.Metrics.BucketHistogram
 {
@@ -14,7 +17,7 @@ namespace App.Metrics.BucketHistogram
         public BucketHistogramValue(
             long count,
             double sum,
-            IReadOnlyDictionary<double, long> buckets)
+            IReadOnlyDictionary<double, double> buckets)
         {
             Count = count;
             Sum = sum;
@@ -25,6 +28,19 @@ namespace App.Metrics.BucketHistogram
 
         public double Sum { get; }
 
-        public IReadOnlyDictionary<double, long> Buckets { get; }
+        public IReadOnlyDictionary<double, double> Buckets { get; }
+
+        public BucketHistogramValue Scale(double factor)
+        {
+            if (Math.Abs(factor - 1.0d) < 0.001)
+            {
+                return this;
+            }
+
+            return new BucketHistogramValue(
+                Count,
+                Sum * factor,
+                Buckets.ToDictionary(x=>x.Key, x => x.Value * factor));
+        }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValue.cs
@@ -14,7 +14,7 @@ namespace App.Metrics.BucketHistogram
         public BucketHistogramValue(
             long count,
             double sum,
-            IReadOnlyDictionary<long, long> buckets)
+            IReadOnlyDictionary<double, long> buckets)
         {
             Count = count;
             Sum = sum;
@@ -25,6 +25,6 @@ namespace App.Metrics.BucketHistogram
 
         public double Sum { get; }
 
-        public IReadOnlyDictionary<long, long> Buckets { get; }
+        public IReadOnlyDictionary<double, long> Buckets { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValueSource.cs
@@ -1,0 +1,21 @@
+// <copyright file="HistogramValueSource.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     Combines the value of the histogram with the defined unit for the value.
+    /// </summary>
+    public sealed class BucketHistogramValueSource : MetricValueSourceBase<BucketHistogramValue>
+    {
+        public BucketHistogramValueSource(
+            string name,
+            IMetricValueProvider<BucketHistogramValue> valueProvider,
+            Unit unit,
+            MetricTags tags)
+            : base(name, valueProvider, unit, tags)
+        {
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogram.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogram.cs
@@ -2,18 +2,15 @@
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
+using App.Metrics.Histogram;
+
 namespace App.Metrics.BucketHistogram
 {
     /// <summary>
     ///     A Histogram measures the distribution of values in a stream of data: e.g., the number of results returned by a
     ///     search.
     /// </summary>
-    public interface IBucketHistogram : IResetableMetric
+    public interface IBucketHistogram : IHistogram
     {
-        /// <summary>
-        ///     Records a value.
-        /// </summary>
-        /// <param name="value">Value to be added to the histogram.</param>
-        void Update(long value);
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogram.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogram.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="IHistogram.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     A Histogram measures the distribution of values in a stream of data: e.g., the number of results returned by a
+    ///     search.
+    /// </summary>
+    public interface IBucketHistogram : IResetableMetric
+    {
+        /// <summary>
+        ///     Records a value.
+        /// </summary>
+        /// <param name="value">Value to be added to the histogram.</param>
+        void Update(long value);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBucketHistogramMetric.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="IHistogramMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     Provides access to a histgram metric implementation, allows custom
+    ///     histograms to be implemented
+    /// </summary>
+    /// <seealso cref="IBucketHistogram" />
+    /// <seealso cref="IMetricValueProvider{T}" />
+    public interface IBucketHistogramMetric : IBucketHistogram, IMetricValueProvider<BucketHistogramValue>, IDisposable
+    {
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBuildBucketHistogramMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBuildBucketHistogramMetrics.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="IBuildHistogramMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace App.Metrics.BucketHistogram
+{
+    public interface IBuildBucketHistogramMetrics
+    {
+        IBucketHistogramMetric Build(IEnumerable<long> buckets);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBuildBucketHistogramMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IBuildBucketHistogramMetrics.cs
@@ -9,6 +9,6 @@ namespace App.Metrics.BucketHistogram
 {
     public interface IBuildBucketHistogramMetrics
     {
-        IBucketHistogramMetric Build(IEnumerable<long> buckets);
+        IBucketHistogramMetric Build(IEnumerable<double> buckets);
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IMeasureBucketHistogramMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IMeasureBucketHistogramMetrics.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="IMeasureHistogramMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+namespace App.Metrics.BucketHistogram
+{
+    /// <summary>
+    ///     Provides access to the API allowing Histogram Metrics to be measured/recorded.
+    /// </summary>
+    public interface IMeasureBucketHistogramMetrics
+    {
+        /// <summary>
+        ///     Updates a <see cref="IBucketHistogramMetric" /> which measures the distribution of values in a stream of data. Records
+        ///     the min, mean,
+        ///     max and standard deviation of values and also quantiles such as the medium, 95th percentile, 98th percentile, 99th
+        ///     percentile and 99.9th percentile
+        /// </summary>
+        /// <param name="options">The details of the histogram that is being measured</param>
+        /// <param name="value">The value to be added to the histogram.</param>
+        void Update(BucketHistogramOptions options, long value);
+
+        /// <summary>
+        ///     Updates a <see cref="IBucketHistogramMetric" /> which measures the distribution of values in a stream of data. Records
+        ///     the min, mean,
+        ///     max and standard deviation of values and also quantiles such as the medium, 95th percentile, 98th percentile, 99th
+        ///     percentile and 99.9th percentile
+        /// </summary>
+        /// <param name="options">The details of the histogram that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <param name="value">The value to be added to the histogram.</param>
+        void Update(BucketHistogramOptions options, MetricTags tags, long value);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IProvideBucketHistogramMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/IProvideBucketHistogramMetrics.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="IProvideHistogramMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace App.Metrics.BucketHistogram
+{
+    public interface IProvideBucketHistogramMetrics
+    {
+        /// <summary>
+        ///     Instantiates an instance of a <see cref="IBucketHistogram" />
+        /// </summary>
+        /// <param name="options">The details of the histogram that is being measured</param>
+        /// <returns>A new instance of an <see cref="IBucketHistogram" /> or the existing registered instance of the histogram</returns>
+        IBucketHistogram Instance(BucketHistogramOptions options);
+
+        /// <summary>
+        ///     Instantiates an instance of a <see cref="IBucketHistogram" />
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IBucketHistogram" /> to instantiate</typeparam>
+        /// <param name="options">The details of the <see cref="IBucketHistogram" /> that is being measured</param>
+        /// <param name="builder">The function used to build the histogram metric.</param>
+        /// <returns>A new instance of an <see cref="IBucketHistogram" /> or the existing registered instance of the histogram</returns>
+        IBucketHistogram Instance<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric;
+
+        /// <summary>
+        ///     Instantiates an instance of a <see cref="IBucketHistogram" />
+        /// </summary>
+        /// <param name="options">The details of the histogram that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <returns>
+        ///     A new instance of an <see cref="IBucketHistogram" /> or the existing registered instance of the histogram
+        /// </returns>
+        IBucketHistogram Instance(BucketHistogramOptions options, MetricTags tags);
+
+        /// <summary>
+        ///     Instantiates an instance of a <see cref="IBucketHistogram" />
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IBucketHistogram" /> to instantiate</typeparam>
+        /// <param name="options">The details of the <see cref="IBucketHistogram" /> that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <param name="builder">The function used to build the histogram metric.</param>
+        /// <returns>
+        ///     A new instance of an <see cref="IBucketHistogram" /> or the existing registered instance of the histogram
+        /// </returns>
+        IBucketHistogram Instance<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric;
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogramFields.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogramFields.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="HistogramFields.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+namespace App.Metrics
+{
+    public enum BucketHistogramFields
+    {
+#pragma warning disable SA1602
+        Count,
+        Sum,
+        Bucket,
+#pragma warning restore SA1602
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerOptions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerOptions.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="TimerOptions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global.
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+
+using System.Collections.Generic;
+
+namespace App.Metrics.BucketTimer
+{
+    public class BucketTimerOptions : MetricValueOptionsBase
+    {
+        public BucketTimerOptions()
+        {
+            DurationUnit = TimeUnit.Milliseconds;
+            RateUnit = TimeUnit.Minutes;
+        }
+
+        /// <summary>
+        ///     Gets or sets the duration unit used for visualization which defaults to Milliseconds
+        /// </summary>
+        /// <value>
+        ///     The duration unit.
+        /// </value>
+        public TimeUnit DurationUnit { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the rate unit used for visualization which defaults to Minutes
+        /// </summary>
+        /// <value>
+        ///     The rate unit.
+        /// </value>
+        public TimeUnit RateUnit { get; set; }
+
+        public IEnumerable<double> Buckets { get; set; }
+    }
+
+    // ReSharper restore AutoPropertyCanBeMadeGetOnly.Global
+    // ReSharper restore MemberCanBePrivate.Global
+    // ReSharper restore AutoPropertyCanBeMadeGetOnly.Global
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValue.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValue.cs
@@ -31,7 +31,7 @@ namespace App.Metrics.BucketTimer
         public BucketTimerValue Scale(TimeUnit rate, TimeUnit duration)
         {
             var durationFactor = DurationUnit.ScalingFactorFor(duration);
-            return new BucketTimerValue(Rate.Scale(rate), Histogram.Scale(durationFactor), ActiveSessions, duration);
+            return new BucketTimerValue(Rate.Scale(rate), Histogram, ActiveSessions, duration);
         }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValue.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValue.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="TimerValue.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using App.Metrics.BucketHistogram;
+using App.Metrics.Meter;
+
+namespace App.Metrics.BucketTimer
+{
+    /// <summary>
+    ///     The value reported by a Timer Metric
+    /// </summary>
+    public sealed class BucketTimerValue
+    {
+        public BucketTimerValue(MeterValue rate, BucketHistogramValue histogram, long activeSessions, TimeUnit durationUnit)
+        {
+            Rate = rate;
+            Histogram = histogram;
+            ActiveSessions = activeSessions;
+            DurationUnit = durationUnit;
+        }
+
+        public long ActiveSessions { get; }
+
+        public BucketHistogramValue Histogram { get; }
+
+        public MeterValue Rate { get; }
+
+        public TimeUnit DurationUnit { get; }
+
+        public BucketTimerValue Scale(TimeUnit rate, TimeUnit duration)
+        {
+            var durationFactor = DurationUnit.ScalingFactorFor(duration);
+            return new BucketTimerValue(Rate.Scale(rate), Histogram.Scale(durationFactor), ActiveSessions, duration);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValueSource.cs
@@ -1,0 +1,29 @@
+// <copyright file="TimerValueSource.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+namespace App.Metrics.BucketTimer
+{
+    /// <summary>
+    ///     Combines the value of the timer with the defined unit and the time units for rate and duration.
+    /// </summary>
+    public sealed class BucketTimerValueSource : MetricValueSourceBase<BucketTimerValue>
+    {
+        public BucketTimerValueSource(
+            string name,
+            IMetricValueProvider<BucketTimerValue> value,
+            Unit unit,
+            TimeUnit rateUnit,
+            TimeUnit durationUnit,
+            MetricTags tags)
+            : base(name, new ScaledValueProvider<BucketTimerValue>(value, v => v.Scale(rateUnit, durationUnit)), unit, tags)
+        {
+            DurationUnit = durationUnit;
+            RateUnit = rateUnit;
+        }
+
+        public TimeUnit DurationUnit { get; }
+
+        public TimeUnit RateUnit { get; }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBucketTimerMetric.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBucketTimerMetric.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="ITimerMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    /// <summary>
+    ///     Provides access to a timer metric implementation, allows custom timers to be implemented
+    /// </summary>
+    /// <seealso cref="IMetricValueProvider{T}" />
+    public interface IBucketTimerMetric : ITimer, IMetricValueProvider<BucketTimerValue>
+    {
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBuildBucketTimerMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBuildBucketTimerMetrics.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="IBuildTimerMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Meter;
+
+namespace App.Metrics.BucketTimer
+{
+    public interface IBuildBucketTimerMetrics
+    {
+        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock);
+
+        IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock);
+
+        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock);
+
+        IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBuildBucketTimerMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/IBuildBucketTimerMetrics.cs
@@ -10,12 +10,12 @@ namespace App.Metrics.BucketTimer
 {
     public interface IBuildBucketTimerMetrics
     {
-        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock);
+        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock, TimeUnit timeUnit);
 
-        IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock);
+        IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock, TimeUnit timeUnit);
 
-        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock);
+        IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock, TimeUnit timeUnit);
 
-        IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock);
+        IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock, TimeUnit timeUnit);
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/IMeasureBucketTimerMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/IMeasureBucketTimerMetrics.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="IMeasureBucketTimerMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    /// <summary>
+    ///     Provides access to the API allowing BucketTimer Metrics to be measured/recorded.
+    /// </summary>
+    public interface IMeasureBucketTimerMetrics
+    {
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="action">The action to measure.</param>
+        void Time(BucketTimerOptions options, Action action);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <param name="action">The action to measure.</param>
+        void Time(BucketTimerOptions options, MetricTags tags, Action action);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="action">The action to measure.</param>
+        /// <param name="userValue">The user value to track where a Min, Max and Last duration is recorded.</param>
+        void Time(BucketTimerOptions options, Action action, string userValue);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <param name="action">The action to measure.</param>
+        /// <param name="userValue">The user value to track where a Min, Max and Last duration is recorded.</param>
+        void Time(BucketTimerOptions options, MetricTags tags, Action action, string userValue);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        /// <param name="userValue">The user value to track where a Min, Max and Last duration is recorded.</param>
+        /// <returns>A disposable context, when disposed records the time token to process the using block</returns>
+        TimerContext Time(BucketTimerOptions options, MetricTags tags, string userValue);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <param name="userValue">The user value to track where a Min, Max and Last duration is recorded.</param>
+        /// <returns>A disposable context, when disposed records the time token to process the using block</returns>
+        TimerContext Time(BucketTimerOptions options, string userValue);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <returns>A disposable context, when disposed records the time token to process the using block</returns>
+        /// <param name="tags">
+        ///     The runtime tags to set in addition to those defined on the options, this will create a separate metric per unique <see cref="MetricTags"/>
+        /// </param>
+        TimerContext Time(BucketTimerOptions options, MetricTags tags);
+
+        /// <summary>
+        ///     Records a <see cref="IBucketTimerMetric" /> which measures the time taken to process an action using a BucketTimer metric.
+        ///     Records a histogram of the duration of a type of event and a meter of the rate of it's occurance
+        /// </summary>
+        /// <param name="options">The details of the BucketTimer that is being measured</param>
+        /// <returns>A disposable context, when disposed records the time token to process the using block</returns>
+        TimerContext Time(BucketTimerOptions options);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/IProvideTimerMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/IProvideTimerMetrics.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="IProvideBucketTimerMetrics.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    public interface IProvideBucketTimerMetrics
+    {
+        ITimer Instance(BucketTimerOptions options);
+
+        ITimer Instance(BucketTimerOptions options, MetricTags tags);
+
+        ITimer Instance<T>(BucketTimerOptions options, Func<T> builder)
+            where T : IBucketTimerMetric;
+
+        ITimer Instance<T>(BucketTimerOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketTimerMetric;
+
+        ITimer WithHistogram<T>(BucketTimerOptions options, Func<T> histogramMetricBuilder)
+            where T : IBucketHistogramMetric;
+
+        ITimer WithHistogram<T>(BucketTimerOptions options, MetricTags tags, Func<T> histogramMetricBuilder)
+            where T : IBucketHistogramMetric;
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/DefaultMetricFieldNames.cs
+++ b/src/Core/src/App.Metrics.Abstractions/DefaultMetricFieldNames.cs
@@ -43,6 +43,13 @@ namespace App.Metrics
                                                                                    { HistogramFields.UserMaxValue, "user.max" }
                                                                                };
 
+        public static IReadOnlyDictionary<BucketHistogramFields, string> BucketHistogram => new Dictionary<BucketHistogramFields, string>
+                                                                               {
+                                                                                   { BucketHistogramFields.Sum, "sum" },
+                                                                                   { BucketHistogramFields.Count, "count.hist" },
+                                                                                   { BucketHistogramFields.Bucket, "bucket" },
+                                                                               };
+
         public static IReadOnlyDictionary<MeterFields, string> Meter => new Dictionary<MeterFields, string>
                                                                        {
                                                                            { MeterFields.Count, "count.meter" },

--- a/src/Core/src/App.Metrics.Abstractions/Filters/IFilterMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Filters/IFilterMetrics.cs
@@ -5,6 +5,7 @@
 using System;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -70,6 +71,13 @@ namespace App.Metrics.Filters
         /// <param name="timer">The timer.</param>
         /// <returns>True if the metric type is a timer, the name matches and tags match</returns>
         bool IsTimerMatch(TimerValueSource timer);
+
+        /// <summary>
+        ///     Determines whether the specified timer is match.
+        /// </summary>
+        /// <param name="timer">The timer.</param>
+        /// <returns>True if the metric type is a timer, the name matches and tags match</returns>
+        bool IsBucketTimerMatch(BucketTimerValueSource timer);
 
         /// <summary>
         ///     Filters metrics where the specified predicate on the metrics context is <c>true</c>

--- a/src/Core/src/App.Metrics.Abstractions/Filters/IFilterMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Filters/IFilterMetrics.cs
@@ -4,6 +4,7 @@
 
 using System;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -41,6 +42,13 @@ namespace App.Metrics.Filters
         /// <param name="histogram">The histogram.</param>
         /// <returns>True if the metric type is a histogram, the name matches and tags match</returns>
         bool IsHistogramMatch(HistogramValueSource histogram);
+
+        /// <summary>
+        ///     Determines whether the specified bucket histogram is match.
+        /// </summary>
+        /// <param name="histogram">The bucket histogram.</param>
+        /// <returns>True if the metric type is a bucket histogram, the name matches and tags match</returns>
+        bool IsBucketHistogramMatch(BucketHistogramValueSource histogram);
 
         /// <summary>
         ///     Determines whether the specified context is match.

--- a/src/Core/src/App.Metrics.Abstractions/IBuildMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/IBuildMetrics.cs
@@ -4,6 +4,7 @@
 
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -74,5 +75,13 @@ namespace App.Metrics
         ///     The Timer API for building <see cref="ITimerMetric" />s
         /// </value>
         IBuildTimerMetrics Timer { get; }
+
+        /// <summary>
+        ///     Gets the Bucket Timer API to build <see cref="IBucketTimerMetric" />s
+        /// </summary>
+        /// <value>
+        ///     The Bucket Timer API for building <see cref="IBucketTimerMetric" />s
+        /// </value>
+        IBuildBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/IBuildMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/IBuildMetrics.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -49,6 +50,14 @@ namespace App.Metrics
         ///     The Histogram API for building <see cref="IHistogramMetric" />s
         /// </value>
         IBuildHistogramMetrics Histogram { get; }
+
+        /// <summary>
+        ///     Gets the Bucket Histogram API to build <see cref="IBucketHistogramMetric" />s
+        /// </summary>
+        /// <value>
+        ///     The Bucket Histogram API for building <see cref="IBucketHistogramMetric" />s
+        /// </value>
+        IBuildBucketHistogramMetrics BucketHistogram { get; }
 
         /// <summary>
         ///     Gets the Meter API to build <see cref="IMeterMetric" />s

--- a/src/Core/src/App.Metrics.Abstractions/IMeasureMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/IMeasureMetrics.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -47,6 +48,14 @@ namespace App.Metrics
         ///     The Histogram API for measuring Histogram metrics
         /// </value>
         IMeasureHistogramMetrics Histogram { get; }
+
+        /// <summary>
+        ///     Gets the available Bucket Histogram API allowing Bucket Histogram metrics to be measured
+        /// </summary>
+        /// <value>
+        ///     The Bucket Histogram API for measuring Bucket Histogram metrics
+        /// </value>
+        IMeasureBucketHistogramMetrics BucketHistogram { get; }
 
         /// <summary>
         ///     Gets the available Meter API allowing Meter metrics to be measured

--- a/src/Core/src/App.Metrics.Abstractions/IMeasureMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/IMeasureMetrics.cs
@@ -4,6 +4,7 @@
 
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -72,5 +73,13 @@ namespace App.Metrics
         ///     The Timer API for measuring Timer metrics
         /// </value>
         IMeasureTimerMetrics Timer { get; }
+
+        /// <summary>
+        ///     Gets the available Timer API allowing Timer metrics to be measured
+        /// </summary>
+        /// <value>
+        ///     The Timer API for measuring Timer metrics
+        /// </value>
+        IMeasureBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/IProvideMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/IProvideMetrics.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -64,5 +65,13 @@ namespace App.Metrics
         ///     The Timer API for registering and retrieving <see cref="ITimerMetric" />s to be measured
         /// </value>
         IProvideTimerMetrics Timer { get; }
+
+        /// <summary>
+        ///     Gets the Bucket Timer API to register and retrieve <see cref="IBucketTimerMetric" />s to be measured.
+        /// </summary>
+        /// <value>
+        ///     The Bucket Timer API for registering and retrieving <see cref="IBucketTimerMetric" />s to be measured
+        /// </value>
+        IProvideBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/MetricFields.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricFields.cs
@@ -12,6 +12,7 @@ namespace App.Metrics
         public MetricFields()
         {
             Histogram = DefaultMetricFieldNames.Histogram.ToDictionary(pair => pair.Key, pair => pair.Value);
+            BucketHistogram = DefaultMetricFieldNames.BucketHistogram.ToDictionary(pair => pair.Key, pair => pair.Value);
             Meter = DefaultMetricFieldNames.Meter.ToDictionary(pair => pair.Key, pair => pair.Value);
             Apdex = DefaultMetricFieldNames.Apdex.ToDictionary(pair => pair.Key, pair => pair.Value);
             Counter = DefaultMetricFieldNames.Counter.ToDictionary(pair => pair.Key, pair => pair.Value);
@@ -25,6 +26,7 @@ namespace App.Metrics
         public IDictionary<GaugeFields, string> Gauge { get; }
 
         public IDictionary<HistogramFields, string> Histogram { get; }
+        public IDictionary<BucketHistogramFields, string> BucketHistogram { get; }
 
         public IDictionary<MeterFields, string> Meter { get; }
     }

--- a/src/Core/src/App.Metrics.Abstractions/MetricType.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricType.cs
@@ -48,6 +48,12 @@ namespace App.Metrics
         Timer,
 
         /// <summary>
+        ///     A <see href="http://app-metrics.io/getting-started/metric-types/histograms.html">Timer</see>
+        ///     Metric
+        /// </summary>
+        BucketTimer,
+
+        /// <summary>
         ///     An <see href="http://app-metrics.io/getting-started/metric-types/apdex.html">Apdex</see>
         ///     Metric
         /// </summary>

--- a/src/Core/src/App.Metrics.Abstractions/MetricType.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricType.cs
@@ -35,6 +35,13 @@ namespace App.Metrics
         Histogram,
 
         /// <summary>
+        ///     A
+        ///     <see href="http://app-metrics.io/getting-started/metric-types/histograms.html">BucketHistogram</see>
+        ///     Metric
+        /// </summary>
+        BucketHistogram,
+
+        /// <summary>
         ///     A <see href="http://app-metrics.io/getting-started/metric-types/histograms.html">Timer</see>
         ///     Metric
         /// </summary>

--- a/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
 
@@ -71,6 +72,31 @@ namespace App.Metrics
             fields.TryAddValuesForKey(values, BucketHistogramFields.Count.ToString(), histogram.Count);
             fields.TryAddValuesForKey(values, BucketHistogramFields.Sum.ToString(), histogram.Sum);
             foreach (var bucket in histogram.Buckets)
+            {
+                if (double.IsPositiveInfinity(bucket.Key))
+                {
+                    values[$"{BucketHistogramFields.Bucket}Inf"] = bucket.Value;
+                }
+                else
+                {
+                    values[$"{BucketHistogramFields.Bucket}{bucket.Key}"] = bucket.Value;
+                }
+            }
+        }
+
+        public static void AddBucketTimerValues(
+            this BucketTimerValue timer,
+            IDictionary<string, object> values,
+            IDictionary<string, string> fields)
+        {
+            if (values == null)
+            {
+                return;
+            }
+
+            fields.TryAddValuesForKey(values, BucketHistogramFields.Count.ToString(), timer.Histogram.Count);
+            fields.TryAddValuesForKey(values, BucketHistogramFields.Sum.ToString(), timer.Histogram.Sum);
+            foreach (var bucket in timer.Histogram.Buckets)
             {
                 if (double.IsPositiveInfinity(bucket.Key))
                 {

--- a/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
@@ -72,7 +72,7 @@ namespace App.Metrics
             fields.TryAddValuesForKey(values, BucketHistogramFields.Sum.ToString(), histogram.Sum);
             foreach (var bucket in histogram.Buckets)
             {
-                if (bucket.Key == long.MaxValue)
+                if (double.IsPositiveInfinity(bucket.Key))
                 {
                     values[$"{BucketHistogramFields.Bucket}Inf"] = bucket.Value;
                 }

--- a/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricValueExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
 
@@ -55,6 +56,31 @@ namespace App.Metrics
             fields.TryAddValuesForKeyIfPresent(values, HistogramFields.UserLastValue, histogram.LastUserValue);
             fields.TryAddValuesForKeyIfPresent(values, HistogramFields.UserMinValue, histogram.MinUserValue);
             fields.TryAddValuesForKeyIfPresent(values, HistogramFields.UserMaxValue, histogram.MaxUserValue);
+        }
+
+        public static void AddBucketHistogramValues(
+            this BucketHistogramValue histogram,
+            IDictionary<string, object> values,
+            IDictionary<string, string> fields)
+        {
+            if (values == null)
+            {
+                return;
+            }
+
+            fields.TryAddValuesForKey(values, BucketHistogramFields.Count.ToString(), histogram.Count);
+            fields.TryAddValuesForKey(values, BucketHistogramFields.Sum.ToString(), histogram.Sum);
+            foreach (var bucket in histogram.Buckets)
+            {
+                if (bucket.Key == long.MaxValue)
+                {
+                    values[$"{BucketHistogramFields.Bucket}Inf"] = bucket.Value;
+                }
+                else
+                {
+                    values[$"{BucketHistogramFields.Bucket}{bucket.Key}"] = bucket.Value;
+                }
+            }
         }
 
         public static void AddMeterSetItemValues(

--- a/src/Core/src/App.Metrics.Abstractions/MetricsContextValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricsContextValueSource.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -25,6 +26,7 @@ namespace App.Metrics
             Enumerable.Empty<HistogramValueSource>(),
             Enumerable.Empty<BucketHistogramValueSource>(),
             Enumerable.Empty<TimerValueSource>(),
+            Enumerable.Empty<BucketTimerValueSource>(),
             Enumerable.Empty<ApdexValueSource>());
 
         public MetricsContextValueSource(
@@ -35,6 +37,7 @@ namespace App.Metrics
             IEnumerable<HistogramValueSource> histograms,
             IEnumerable<BucketHistogramValueSource> bucketHistograms,
             IEnumerable<TimerValueSource> timers,
+            IEnumerable<BucketTimerValueSource> bucketTimers,
             IEnumerable<ApdexValueSource> apdexScores)
         {
             Context = context;
@@ -44,6 +47,7 @@ namespace App.Metrics
             Histograms = histograms;
             BucketHistograms = bucketHistograms;
             Timers = timers;
+            BucketTimers = bucketTimers;
             ApdexScores = apdexScores;
         }
 
@@ -62,6 +66,8 @@ namespace App.Metrics
 
         public IEnumerable<TimerValueSource> Timers { get; }
 
+        public IEnumerable<BucketTimerValueSource> BucketTimers { get; }
+
         public MetricsContextValueSource Filter(IFilterMetrics filter)
         {
             if (!filter.IsContextMatch(Context))
@@ -77,6 +83,7 @@ namespace App.Metrics
                 Histograms.Where(filter.IsHistogramMatch),
                 BucketHistograms.Where(filter.IsBucketHistogramMatch),
                 Timers.Where(filter.IsTimerMatch),
+                BucketTimers.Where(filter.IsBucketTimerMatch),
                 ApdexScores.Where(filter.IsApdexMatch));
         }
 

--- a/src/Core/src/App.Metrics.Abstractions/MetricsContextValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricsContextValueSource.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -22,6 +23,7 @@ namespace App.Metrics
             Enumerable.Empty<CounterValueSource>(),
             Enumerable.Empty<MeterValueSource>(),
             Enumerable.Empty<HistogramValueSource>(),
+            Enumerable.Empty<BucketHistogramValueSource>(),
             Enumerable.Empty<TimerValueSource>(),
             Enumerable.Empty<ApdexValueSource>());
 
@@ -31,6 +33,7 @@ namespace App.Metrics
             IEnumerable<CounterValueSource> counters,
             IEnumerable<MeterValueSource> meters,
             IEnumerable<HistogramValueSource> histograms,
+            IEnumerable<BucketHistogramValueSource> bucketHistograms,
             IEnumerable<TimerValueSource> timers,
             IEnumerable<ApdexValueSource> apdexScores)
         {
@@ -39,6 +42,7 @@ namespace App.Metrics
             Counters = counters;
             Meters = meters;
             Histograms = histograms;
+            BucketHistograms = bucketHistograms;
             Timers = timers;
             ApdexScores = apdexScores;
         }
@@ -52,6 +56,7 @@ namespace App.Metrics
         public IEnumerable<GaugeValueSource> Gauges { get; }
 
         public IEnumerable<HistogramValueSource> Histograms { get; }
+        public IEnumerable<BucketHistogramValueSource> BucketHistograms { get; }
 
         public IEnumerable<MeterValueSource> Meters { get; }
 
@@ -70,6 +75,7 @@ namespace App.Metrics
                 Counters.Where(filter.IsCounterMatch),
                 Meters.Where(filter.IsMeterMatch),
                 Histograms.Where(filter.IsHistogramMatch),
+                BucketHistograms.Where(filter.IsBucketHistogramMatch),
                 Timers.Where(filter.IsTimerMatch),
                 ApdexScores.Where(filter.IsApdexMatch));
         }

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricContextRegistry.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricContextRegistry.cs
@@ -5,6 +5,7 @@
 using System;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -62,5 +63,11 @@ namespace App.Metrics.Registry
 
         ITimer Timer<T>(TimerOptions options, MetricTags tags, Func<T> builder)
             where T : ITimerMetric;
+
+        ITimer BucketTimer<T>(BucketTimerOptions options, Func<T> builder)
+            where T : IBucketTimerMetric;
+
+        ITimer BucketTimer<T>(BucketTimerOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketTimerMetric;
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricContextRegistry.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricContextRegistry.cs
@@ -4,6 +4,7 @@
 
 using System;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -43,6 +44,12 @@ namespace App.Metrics.Registry
 
         IHistogram Histogram<T>(HistogramOptions options, MetricTags tags, Func<T> builder)
             where T : IHistogramMetric;
+
+        IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric;
+
+        IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric;
 
         IMeter Meter<T>(MeterOptions options, Func<T> builder)
             where T : IMeterMetric;

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricRegistryManager.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricRegistryManager.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -21,6 +22,8 @@ namespace App.Metrics.Registry
         IEnumerable<GaugeValueSource> Gauges { get; }
 
         IEnumerable<HistogramValueSource> Histograms { get; }
+
+        IEnumerable<BucketHistogramValueSource> BucketHistograms { get; }
 
         IEnumerable<MeterValueSource> Meters { get; }
 

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricRegistryManager.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricRegistryManager.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -28,5 +29,7 @@ namespace App.Metrics.Registry
         IEnumerable<MeterValueSource> Meters { get; }
 
         IEnumerable<TimerValueSource> Timers { get; }
+
+        IEnumerable<BucketTimerValueSource> BucketTimers { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricsRegistry.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricsRegistry.cs
@@ -5,6 +5,7 @@
 using System;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -65,5 +66,11 @@ namespace App.Metrics.Registry
 
         ITimer Timer<T>(TimerOptions options, MetricTags tags, Func<T> builder)
             where T : ITimerMetric;
+
+        ITimer BucketTimer<T>(BucketTimerOptions options, Func<T> builder)
+            where T : IBucketTimerMetric;
+
+        ITimer BucketTimer<T>(BucketTimerOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketTimerMetric;
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/Registry/IMetricsRegistry.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Registry/IMetricsRegistry.cs
@@ -4,6 +4,7 @@
 
 using System;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -44,6 +45,12 @@ namespace App.Metrics.Registry
 
         IHistogram Histogram<T>(HistogramOptions options, MetricTags tags, Func<T> builder)
             where T : IHistogramMetric;
+
+        IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric;
+
+        IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric;
 
         IMeter Meter<T>(MeterOptions options, Func<T> builder)
             where T : IMeterMetric;

--- a/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotSerializer.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotSerializer.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
@@ -57,6 +59,11 @@ namespace App.Metrics.Serialization
                 {
                     BuildMetricPayload(contextValueSource.Context, valueSource, writer, fields, metricsData.Timestamp);
                 }
+
+                foreach (var valueSource in contextValueSource.BucketHistograms)
+                {
+                    BuildMetricPayload(contextValueSource.Context, valueSource, writer, fields, metricsData.Timestamp);
+                }
             }
         }
 
@@ -99,6 +106,16 @@ namespace App.Metrics.Serialization
             DateTime timestamp)
         {
             writer.WriteHistogram(context, valueSource, fields, timestamp);
+        }
+
+        private static void BuildBucketHistogramPayload(
+            string context,
+            MetricValueSourceBase<BucketHistogramValue> valueSource,
+            IMetricSnapshotWriter writer,
+            IDictionary<string, string> fields,
+            DateTime timestamp)
+        {
+            writer.WriteBucketHistogram(context, valueSource, fields, timestamp);
         }
 
         private static void BuildMeterPayload(
@@ -145,6 +162,12 @@ namespace App.Metrics.Serialization
             if (typeof(TMetric) == typeof(HistogramValue))
             {
                 BuildHistogramPayload(context, valueSource as MetricValueSourceBase<HistogramValue>, writer, fields.Histogram, timestamp);
+                return;
+            }
+
+            if (typeof(TMetric) == typeof(BucketHistogramValue))
+            {
+                BuildBucketHistogramPayload(context, valueSource as MetricValueSourceBase<BucketHistogramValue>, writer, fields.BucketHistogram.ToDictionary(x => x.Key.ToString(), x => x.Value), timestamp);
                 return;
             }
 

--- a/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotWriterExtensions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotWriterExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
@@ -134,6 +135,23 @@ namespace App.Metrics.Serialization
 
             var data = new Dictionary<string, object>();
             valueSource.Value.AddBucketHistogramValues(data, fields);
+            WriteMetric(writer, context, valueSource, data, timestamp);
+        }
+
+        public static void WriteBucketTimer(
+            this IMetricSnapshotWriter writer,
+            string context,
+            MetricValueSourceBase<BucketTimerValue> valueSource,
+            IDictionary<string, string> fields,
+            DateTime timestamp)
+        {
+            if (valueSource == null || fields.Count == 0)
+            {
+                return;
+            }
+
+            var data = new Dictionary<string, object>();
+            valueSource.Value.AddBucketTimerValues(data, fields);
             WriteMetric(writer, context, valueSource, data, timestamp);
         }
 

--- a/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotWriterExtensions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Serialization/MetricSnapshotWriterExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
@@ -116,6 +117,23 @@ namespace App.Metrics.Serialization
 
             var data = new Dictionary<string, object>();
             valueSource.Value.AddHistogramValues(data, fields);
+            WriteMetric(writer, context, valueSource, data, timestamp);
+        }
+
+        public static void WriteBucketHistogram(
+            this IMetricSnapshotWriter writer,
+            string context,
+            MetricValueSourceBase<BucketHistogramValue> valueSource,
+            IDictionary<string, string> fields,
+            DateTime timestamp)
+        {
+            if (valueSource == null || fields.Count == 0)
+            {
+                return;
+            }
+
+            var data = new Dictionary<string, object>();
+            valueSource.Value.AddBucketHistogramValues(data, fields);
             WriteMetric(writer, context, valueSource, data, timestamp);
         }
 

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramBuilder.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramBuilder.cs
@@ -10,7 +10,7 @@ namespace App.Metrics.BucketHistogram
     public class DefaultBucketHistogramBuilder : IBuildBucketHistogramMetrics
     {
         /// <inheritdoc />
-        public IBucketHistogramMetric Build(IEnumerable<long> buckets)
+        public IBucketHistogramMetric Build(IEnumerable<double> buckets)
         {
             return new DefaultBucketHistogramMetric(buckets);
         }

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramBuilder.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramBuilder.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="DefaultHistogramBuilder.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace App.Metrics.BucketHistogram
+{
+    public class DefaultBucketHistogramBuilder : IBuildBucketHistogramMetrics
+    {
+        /// <inheritdoc />
+        public IBucketHistogramMetric Build(IEnumerable<long> buckets)
+        {
+            return new DefaultBucketHistogramMetric(buckets);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramManager.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramManager.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="DefaultHistogramManager.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using App.Metrics.Registry;
+
+namespace App.Metrics.BucketHistogram
+{
+    internal sealed class DefaultBucketHistogramManager : IMeasureBucketHistogramMetrics
+    {
+        private readonly IBuildBucketHistogramMetrics _histogramBuilder;
+        private readonly IMetricsRegistry _registry;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketHistogramManager" /> class.
+        /// </summary>
+        /// <param name="registry">The registry storing all metric data.</param>
+        /// <param name="histogramBuilder">The histogram builder.</param>
+        public DefaultBucketHistogramManager(IBuildBucketHistogramMetrics histogramBuilder, IMetricsRegistry registry)
+        {
+            _registry = registry;
+            _histogramBuilder = histogramBuilder;
+        }
+
+        /// <inheritdoc />
+        public void Update(BucketHistogramOptions options, long value)
+        {
+            _registry.BucketHistogram(options, () => _histogramBuilder.Build(options.Buckets)).Update(value);
+        }
+
+        /// <inheritdoc />
+        public void Update(BucketHistogramOptions options, MetricTags tags, long value)
+        {
+            _registry.BucketHistogram(options, tags, () => _histogramBuilder.Build(options.Buckets)).Update(value);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
@@ -15,12 +15,12 @@ namespace App.Metrics.BucketHistogram
         private bool _disposed;
         private readonly StripedLongAdder _counter = new StripedLongAdder();
         private readonly StripedLongAdder _sum = new StripedLongAdder();
-        private readonly SortedDictionary<long, StripedLongAdder> _buckets = new SortedDictionary<long, StripedLongAdder>(new LongReverseCompare());
+        private readonly SortedDictionary<double, StripedLongAdder> _buckets = new SortedDictionary<double, StripedLongAdder>(new DoubleReverseCompare());
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="DefaultBucketHistogramMetric" /> class.
         /// </summary>
-        public DefaultBucketHistogramMetric(IEnumerable<long> buckets)
+        public DefaultBucketHistogramMetric(IEnumerable<double> buckets)
         {
             if (buckets != null)
             {
@@ -30,7 +30,7 @@ namespace App.Metrics.BucketHistogram
                 }
             }
 
-            _buckets.Add(long.MaxValue, new StripedLongAdder());
+            _buckets.Add(double.PositiveInfinity, new StripedLongAdder());
         }
 
         public BucketHistogramValue Value => GetValue();
@@ -99,9 +99,9 @@ namespace App.Metrics.BucketHistogram
             _counter.Increment();
         }
 
-        private class LongReverseCompare : IComparer<long>
+        private class DoubleReverseCompare : IComparer<double>
         {
-            public int Compare(long x, long y)
+            public int Compare(double x, double y)
             {
                 if (x < y)
                     return 1;

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
@@ -60,7 +60,7 @@ namespace App.Metrics.BucketHistogram
         /// <inheritdoc />
         public BucketHistogramValue GetValue(bool resetMetric = false)
         {
-            var value = new BucketHistogramValue(_counter.GetValue(), _sum.GetValue(), _buckets.ToDictionary(x => x.Key, x => (double)x.Value.GetValue()));
+            var value = new BucketHistogramValue(_counter.GetValue(), _sum.GetValue(), _buckets.ToDictionary(x => x.Key, x => Convert.ToDouble(x.Value.GetValue())));
 
             if (resetMetric)
             {

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
@@ -1,0 +1,116 @@
+﻿// <copyright file="DefaultHistogramMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using App.Metrics.Concurrency;
+
+namespace App.Metrics.BucketHistogram
+{
+    public sealed class DefaultBucketHistogramMetric : IBucketHistogramMetric
+    {
+        private bool _disposed;
+        private readonly StripedLongAdder _counter = new StripedLongAdder();
+        private readonly StripedLongAdder _sum = new StripedLongAdder();
+        private readonly SortedDictionary<long, StripedLongAdder> _buckets = new SortedDictionary<long, StripedLongAdder>(new LongReverseCompare());
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketHistogramMetric" /> class.
+        /// </summary>
+        public DefaultBucketHistogramMetric(IEnumerable<long> buckets)
+        {
+            if (buckets != null)
+            {
+                foreach (var bucket in buckets)
+                {
+                    _buckets.Add(bucket, new StripedLongAdder());
+                }
+            }
+
+            _buckets.Add(long.MaxValue, new StripedLongAdder());
+        }
+
+        public BucketHistogramValue Value => GetValue();
+
+        [ExcludeFromCodeCoverage]
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        [ExcludeFromCodeCoverage]
+        // ReSharper disable MemberCanBePrivate.Global
+        public void Dispose(bool disposing)
+        // ReSharper restore MemberCanBePrivate.Global
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    // Free any other managed objects here.
+                }
+            }
+
+            _disposed = true;
+        }
+
+        /// <inheritdoc />
+        public BucketHistogramValue GetValue(bool resetMetric = false)
+        {
+            var value = new BucketHistogramValue(_counter.GetValue(), _sum.GetValue(), _buckets.ToDictionary(x => x.Key, x => x.Value.GetValue()));
+
+            if (resetMetric)
+            {
+                Reset();
+            }
+
+            return value;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            foreach (var bucket in _buckets)
+            {
+                bucket.Value.Reset();
+            }
+            _sum.Reset();
+            _counter.Reset();
+        }
+
+        /// <inheritdoc />
+        public void Update(long value)
+        {
+            StripedLongAdder bucketCounter = null;
+            foreach (var kvp in _buckets)
+            {
+                if (kvp.Key < value)
+                    break;
+
+                bucketCounter = kvp.Value;
+            }
+
+
+            bucketCounter.Add(value);
+            _sum.Add(value);
+            _counter.Increment();
+        }
+
+        private class LongReverseCompare : IComparer<long>
+        {
+            public int Compare(long x, long y)
+            {
+                if (x < y)
+                    return 1;
+
+                if (x > y)
+                    return -1;
+
+                return 0;
+            }
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetric.cs
@@ -60,7 +60,7 @@ namespace App.Metrics.BucketHistogram
         /// <inheritdoc />
         public BucketHistogramValue GetValue(bool resetMetric = false)
         {
-            var value = new BucketHistogramValue(_counter.GetValue(), _sum.GetValue(), _buckets.ToDictionary(x => x.Key, x => x.Value.GetValue()));
+            var value = new BucketHistogramValue(_counter.GetValue(), _sum.GetValue(), _buckets.ToDictionary(x => x.Key, x => (double)x.Value.GetValue()));
 
             if (resetMetric)
             {
@@ -81,6 +81,11 @@ namespace App.Metrics.BucketHistogram
             _counter.Reset();
         }
 
+        public void Update(long value, string userValue)
+        {
+            Update(value);
+        }
+
         /// <inheritdoc />
         public void Update(long value)
         {
@@ -94,7 +99,7 @@ namespace App.Metrics.BucketHistogram
             }
 
 
-            bucketCounter.Add(value);
+            bucketCounter.Increment();
             _sum.Add(value);
             _counter.Increment();
         }

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetricProvider.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/DefaultBucketHistogramMetricProvider.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="DefaultHistogramMetricProvider.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.Histogram;
+using App.Metrics.Registry;
+
+namespace App.Metrics.BucketHistogram
+{
+    public class DefaultBucketHistogramMetricProvider : IProvideBucketHistogramMetrics
+    {
+        private readonly IBuildBucketHistogramMetrics _histogramBuilder;
+        private readonly IMetricsRegistry _registry;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultHistogramMetricProvider" /> class.
+        /// </summary>
+        /// <param name="histogramBuilder">The histogram builder.</param>
+        /// <param name="registry">The registry.</param>
+        public DefaultBucketHistogramMetricProvider(IBuildBucketHistogramMetrics histogramBuilder, IMetricsRegistry registry)
+        {
+            _registry = registry;
+            _histogramBuilder = histogramBuilder;
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram Instance(BucketHistogramOptions options)
+        {
+            return Instance(options, () => _histogramBuilder.Build(options.Buckets));
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram Instance<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            return _registry.BucketHistogram(options, builder);
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram Instance(BucketHistogramOptions options, MetricTags tags)
+        {
+            return Instance(options, tags, () => _histogramBuilder.Build(options.Buckets));
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram Instance<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            return _registry.BucketHistogram(options, tags, builder);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
@@ -13,7 +13,7 @@ namespace App.Metrics.Histogram
 {
     public static class BucketHistogramExtensions
     {
-        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0,0, new ReadOnlyDictionary<long, long>(new Dictionary<long, long>()));
+        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0,0, new ReadOnlyDictionary<double, long>(new Dictionary<double, long>()));
 
         public static BucketHistogramValue GetBucketHistogramValue(this IProvideMetricValues valueService, string context, string metricName)
         {

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
@@ -13,7 +13,7 @@ namespace App.Metrics.Histogram
 {
     public static class BucketHistogramExtensions
     {
-        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0,0, new ReadOnlyDictionary<double, long>(new Dictionary<double, long>()));
+        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0,0, new ReadOnlyDictionary<double, double>(new Dictionary<double, double>()));
 
         public static BucketHistogramValue GetBucketHistogramValue(this IProvideMetricValues valueService, string context, string metricName)
         {

--- a/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/BucketHistogram/Extensions/BucketHistogramExtensions.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="HistogramExtensions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+// ReSharper disable CheckNamespace
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using App.Metrics.BucketHistogram;
+
+namespace App.Metrics.Histogram
+    // ReSharper restore CheckNamespace
+{
+    public static class BucketHistogramExtensions
+    {
+        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0,0, new ReadOnlyDictionary<long, long>(new Dictionary<long, long>()));
+
+        public static BucketHistogramValue GetBucketHistogramValue(this IProvideMetricValues valueService, string context, string metricName)
+        {
+            return valueService.GetForContext(context).BucketHistograms.ValueFor(metricName);
+        }
+
+        public static BucketHistogramValue GetBucketHistogramValue(this IProvideMetricValues valueService, string context, string metricName, MetricTags tags)
+        {
+            return valueService.GetForContext(context).BucketHistograms.ValueFor(tags.AsMetricName(metricName));
+        }
+
+        public static BucketHistogramValue GetValueOrDefault(this IBucketHistogram metric)
+        {
+            var implementation = metric as IBucketHistogramMetric;
+            return implementation != null ? implementation.Value : EmptyHistogram;
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerBuilder.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerBuilder.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="DefaultTimerBuilder.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Meter;
+
+namespace App.Metrics.BucketTimer
+{
+    public class DefaultBucketTimerBuilder : IBuildBucketTimerMetrics
+    {
+        public DefaultBucketTimerBuilder()
+        {
+        }
+
+        /// <inheritdoc />
+        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock)
+        {
+            return new DefaultBucketTimerMetric(histogram, clock);
+        }
+
+        /// <inheritdoc />
+        public IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock)
+        {
+            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), clock);
+        }
+
+        /// <inheritdoc />
+        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock)
+        {
+            return new DefaultBucketTimerMetric(histogram, meter, clock);
+        }
+
+        /// <inheritdoc />
+        public IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock)
+        {
+            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), meter, clock);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerBuilder.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerBuilder.cs
@@ -15,27 +15,27 @@ namespace App.Metrics.BucketTimer
         }
 
         /// <inheritdoc />
-        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock)
+        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IClock clock, TimeUnit timeUnit)
         {
-            return new DefaultBucketTimerMetric(histogram, clock);
+            return new DefaultBucketTimerMetric(histogram, clock, timeUnit);
         }
 
         /// <inheritdoc />
-        public IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock)
+        public IBucketTimerMetric Build(IEnumerable<double> buckets, IClock clock, TimeUnit timeUnit)
         {
-            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), clock);
+            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), clock, timeUnit);
         }
 
         /// <inheritdoc />
-        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock)
+        public IBucketTimerMetric Build(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock, TimeUnit timeUnit)
         {
-            return new DefaultBucketTimerMetric(histogram, meter, clock);
+            return new DefaultBucketTimerMetric(histogram, meter, clock, timeUnit);
         }
 
         /// <inheritdoc />
-        public IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock)
+        public IBucketTimerMetric Build(IEnumerable<double> buckets, IMeterMetric meter, IClock clock, TimeUnit timeUnit)
         {
-            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), meter, clock);
+            return new DefaultBucketTimerMetric(new DefaultBucketHistogramMetric(buckets), meter, clock, timeUnit);
         }
     }
 }

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerManager.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerManager.cs
@@ -33,7 +33,7 @@ namespace App.Metrics.BucketTimer
             using (
                 _registry.BucketTimer(
                               options,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext())
             {
                 action();
@@ -47,7 +47,7 @@ namespace App.Metrics.BucketTimer
                 _registry.BucketTimer(
                               options,
                               tags,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext())
             {
                 action();
@@ -60,7 +60,7 @@ namespace App.Metrics.BucketTimer
             using (
                 _registry.BucketTimer(
                               options,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext(userValue))
             {
                 action();
@@ -74,7 +74,7 @@ namespace App.Metrics.BucketTimer
                 _registry.BucketTimer(
                               options,
                               tags,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext(userValue))
             {
                 action();
@@ -87,9 +87,7 @@ namespace App.Metrics.BucketTimer
             return _registry.BucketTimer(
                                  options,
                                  tags,
-                                 () => _timerBuilder.Build(
-                                     options.Buckets,
-                                     _clock)).
+                                 () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                              NewContext(userValue);
         }
 
@@ -100,7 +98,7 @@ namespace App.Metrics.BucketTimer
                 _registry.BucketTimer(
                               options,
                               tags,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext();
         }
 
@@ -110,7 +108,7 @@ namespace App.Metrics.BucketTimer
             return
                 _registry.BucketTimer(
                               options,
-                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                              () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                           NewContext();
         }
 
@@ -119,9 +117,7 @@ namespace App.Metrics.BucketTimer
         {
             return _registry.BucketTimer(
                                  options,
-                                 () => _timerBuilder.Build(
-                                     options.Buckets,
-                                     _clock)).
+                                 () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit)).
                              NewContext(userValue);
         }
     }

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerManager.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerManager.cs
@@ -1,0 +1,128 @@
+﻿// <copyright file="DefaultTimerManager.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.Registry;
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    internal sealed class DefaultBucketTimerManager : IMeasureBucketTimerMetrics
+    {
+        private readonly IClock _clock;
+        private readonly IMetricsRegistry _registry;
+        private readonly IBuildBucketTimerMetrics _timerBuilder;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketTimerManager" /> class.
+        /// </summary>
+        /// <param name="registry">The registry storing all metric data.</param>
+        /// <param name="timerBuilder">The timer builder.</param>
+        /// <param name="clock">The clock.</param>
+        public DefaultBucketTimerManager(IBuildBucketTimerMetrics timerBuilder, IMetricsRegistry registry, IClock clock)
+        {
+            _clock = clock;
+            _registry = registry;
+            _timerBuilder = timerBuilder;
+        }
+
+        /// <inheritdoc />
+        public void Time(BucketTimerOptions options, Action action)
+        {
+            using (
+                _registry.BucketTimer(
+                              options,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext())
+            {
+                action();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Time(BucketTimerOptions options, MetricTags tags, Action action)
+        {
+            using (
+                _registry.BucketTimer(
+                              options,
+                              tags,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext())
+            {
+                action();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Time(BucketTimerOptions options, Action action, string userValue)
+        {
+            using (
+                _registry.BucketTimer(
+                              options,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext(userValue))
+            {
+                action();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Time(BucketTimerOptions options, MetricTags tags, Action action, string userValue)
+        {
+            using (
+                _registry.BucketTimer(
+                              options,
+                              tags,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext(userValue))
+            {
+                action();
+            }
+        }
+
+        /// <inheritdoc />
+        public TimerContext Time(BucketTimerOptions options, MetricTags tags, string userValue)
+        {
+            return _registry.BucketTimer(
+                                 options,
+                                 tags,
+                                 () => _timerBuilder.Build(
+                                     options.Buckets,
+                                     _clock)).
+                             NewContext(userValue);
+        }
+
+        /// <inheritdoc />
+        public TimerContext Time(BucketTimerOptions options, MetricTags tags)
+        {
+            return
+                _registry.BucketTimer(
+                              options,
+                              tags,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext();
+        }
+
+        /// <inheritdoc />
+        public TimerContext Time(BucketTimerOptions options)
+        {
+            return
+                _registry.BucketTimer(
+                              options,
+                              () => _timerBuilder.Build(options.Buckets, _clock)).
+                          NewContext();
+        }
+
+        /// <inheritdoc />
+        public TimerContext Time(BucketTimerOptions options, string userValue)
+        {
+            return _registry.BucketTimer(
+                                 options,
+                                 () => _timerBuilder.Build(
+                                     options.Buckets,
+                                     _clock)).
+                             NewContext(userValue);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetric.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetric.cs
@@ -1,0 +1,187 @@
+﻿// <copyright file="DefaultTimerMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Concurrency;
+using App.Metrics.Histogram;
+using App.Metrics.Meter;
+using App.Metrics.ReservoirSampling;
+using App.Metrics.Scheduling;
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    public sealed class DefaultBucketTimerMetric : IBucketTimerMetric, IDisposable
+    {
+        private readonly StripedLongAdder _activeSessionsCounter = new StripedLongAdder();
+        private readonly IClock _clock;
+        private readonly IBucketHistogramMetric _histogram;
+        private readonly IMeterMetric _meter;
+        private bool _disposed;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketTimerMetric" /> class.
+        /// </summary>
+        /// <param name="histogram">The histogram implementation to use.</param>
+        /// <param name="clock">The clock to use to measure processing duration.</param>
+        public DefaultBucketTimerMetric(IBucketHistogramMetric histogram, IClock clock)
+        {
+            _clock = clock;
+            _histogram = histogram;
+            _meter = new DefaultMeterMetric(clock);
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketTimerMetric" /> class.
+        /// </summary>
+        /// <param name="histogram">The histogram implementation to use.</param>
+        /// <param name="meter">The meter implementation to use to genreate the rate of events over time.</param>
+        /// <param name="clock">The clock to use to measure processing duration.</param>
+        public DefaultBucketTimerMetric(IBucketHistogramMetric histogram, IMeterMetric meter, IClock clock)
+        {
+            _clock = clock;
+            _meter = meter;
+            _histogram = histogram;
+        }
+
+        /// <inheritdoc />
+        public BucketTimerValue Value => GetValue();
+
+        /// <inheritdoc />
+        public long CurrentTime()
+        {
+            return _clock.Nanoseconds;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        // ReSharper disable MemberCanBePrivate.Global
+        public void Dispose(bool disposing)
+            // ReSharper restore MemberCanBePrivate.Global
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    // Free any other managed objects here.
+                    _histogram?.Dispose();
+                    _meter?.Dispose();
+                }
+            }
+
+            _disposed = true;
+        }
+
+        /// <inheritdoc />
+        public long EndRecording()
+        {
+            _activeSessionsCounter.Decrement();
+            return _clock.Nanoseconds;
+        }
+
+        /// <inheritdoc />
+        public BucketTimerValue GetValue(bool resetMetric = false)
+        {
+            return new BucketTimerValue(
+                _meter.GetValue(resetMetric),
+                _histogram.GetValue(resetMetric),
+                _activeSessionsCounter.GetValue(),
+                TimeUnit.Nanoseconds);
+        }
+
+        /// <inheritdoc />
+        public TimerContext NewContext(string userValue)
+        {
+            return new TimerContext(this, userValue);
+        }
+
+        /// <inheritdoc />
+        public TimerContext NewContext()
+        {
+            return NewContext(null);
+        }
+
+        /// <inheritdoc />
+        public void Record(long duration, TimeUnit unit, string userValue)
+        {
+            var nanos = unit.ToNanoseconds(duration);
+            if (nanos < 0)
+            {
+                return;
+            }
+
+            _histogram.Update(nanos, userValue);
+            _meter.Mark();
+        }
+
+        /// <inheritdoc />
+        public void Record(long time, TimeUnit unit)
+        {
+            Record(time, unit, null);
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            _meter.Reset();
+            _histogram.Reset();
+        }
+
+        /// <inheritdoc />
+        public long StartRecording()
+        {
+            _activeSessionsCounter.Increment();
+            return _clock.Nanoseconds;
+        }
+
+        /// <inheritdoc />
+        public void Time(Action action, string userValue)
+        {
+            var start = _clock.Nanoseconds;
+            try
+            {
+                _activeSessionsCounter.Increment();
+                action();
+            }
+            finally
+            {
+                _activeSessionsCounter.Decrement();
+                Record(_clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
+
+        /// <inheritdoc />
+        public T Time<T>(Func<T> action, string userValue)
+        {
+            var start = _clock.Nanoseconds;
+            try
+            {
+                _activeSessionsCounter.Increment();
+                return action();
+            }
+            finally
+            {
+                _activeSessionsCounter.Decrement();
+                Record(_clock.Nanoseconds - start, TimeUnit.Nanoseconds, userValue);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Time(Action action)
+        {
+            Time(action, null);
+        }
+
+        /// <inheritdoc />
+        public T Time<T>(Func<T> action)
+        {
+            return Time(action, null);
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetricProvider.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetricProvider.cs
@@ -33,7 +33,7 @@ namespace App.Metrics.BucketTimer
         {
             return Instance(
                 options,
-                () => _timerBuilder.Build(options.Buckets, _clock));
+                () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit));
         }
 
         /// <inheritdoc />
@@ -42,7 +42,7 @@ namespace App.Metrics.BucketTimer
             return Instance(
                 options,
                 tags,
-                () => _timerBuilder.Build(options.Buckets, _clock));
+                () => _timerBuilder.Build(options.Buckets, _clock, options.DurationUnit));
         }
 
         /// <inheritdoc />
@@ -64,7 +64,7 @@ namespace App.Metrics.BucketTimer
         {
             return Instance(
                 options,
-                () => _timerBuilder.Build(histogramMetricBuilder(), _clock));
+                () => _timerBuilder.Build(histogramMetricBuilder(), _clock, options.DurationUnit));
         }
 
         /// <inheritdoc />
@@ -74,7 +74,7 @@ namespace App.Metrics.BucketTimer
             return Instance(
                 options,
                 tags,
-                () => _timerBuilder.Build(histogramMetricBuilder(), _clock));
+                () => _timerBuilder.Build(histogramMetricBuilder(), _clock, options.DurationUnit));
         }
     }
 }

--- a/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetricProvider.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/DefaultBucketTimerMetricProvider.cs
@@ -1,0 +1,80 @@
+﻿// <copyright file="DefaultTimerMetricProvider.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Registry;
+using App.Metrics.Timer;
+
+namespace App.Metrics.BucketTimer
+{
+    public class DefaultBucketTimerMetricProvider : IProvideBucketTimerMetrics
+    {
+        private readonly IClock _clock;
+        private readonly IMetricsRegistry _registry;
+        private readonly IBuildBucketTimerMetrics _timerBuilder;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DefaultBucketTimerMetricProvider" /> class.
+        /// </summary>
+        /// <param name="timerBuilder">The timer builder.</param>
+        /// <param name="registry">The metrics registry.</param>
+        /// <param name="clock">The clock.</param>
+        public DefaultBucketTimerMetricProvider(IBuildBucketTimerMetrics timerBuilder, IMetricsRegistry registry, IClock clock)
+        {
+            _registry = registry;
+            _clock = clock;
+            _timerBuilder = timerBuilder;
+        }
+
+        /// <inheritdoc />
+        public ITimer Instance(BucketTimerOptions options)
+        {
+            return Instance(
+                options,
+                () => _timerBuilder.Build(options.Buckets, _clock));
+        }
+
+        /// <inheritdoc />
+        public ITimer Instance(BucketTimerOptions options, MetricTags tags)
+        {
+            return Instance(
+                options,
+                tags,
+                () => _timerBuilder.Build(options.Buckets, _clock));
+        }
+
+        /// <inheritdoc />
+        public ITimer Instance<T>(BucketTimerOptions options, Func<T> builder)
+            where T : IBucketTimerMetric
+        {
+            return _registry.BucketTimer(options, builder);
+        }
+
+        public ITimer Instance<T>(BucketTimerOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketTimerMetric
+        {
+            return _registry.BucketTimer(options, tags, builder);
+        }
+
+        /// <inheritdoc />
+        public ITimer WithHistogram<T>(BucketTimerOptions options, Func<T> histogramMetricBuilder)
+            where T : IBucketHistogramMetric
+        {
+            return Instance(
+                options,
+                () => _timerBuilder.Build(histogramMetricBuilder(), _clock));
+        }
+
+        /// <inheritdoc />
+        public ITimer WithHistogram<T>(BucketTimerOptions options, MetricTags tags, Func<T> histogramMetricBuilder)
+            where T : IBucketHistogramMetric
+        {
+            return Instance(
+                options,
+                tags,
+                () => _timerBuilder.Build(histogramMetricBuilder(), _clock));
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/BucketTimer/Extensions/TimerExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/BucketTimer/Extensions/TimerExtensions.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="TimerExtensions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
+using App.Metrics.Histogram;
+using App.Metrics.Meter;
+
+// ReSharper disable CheckNamespace
+namespace App.Metrics.Timer
+    // ReSharper restore CheckNamespace
+{
+    public static class BucketTimerExtensions
+    {
+        private static readonly BucketHistogramValue EmptyHistogram = new BucketHistogramValue(0, 0, new ReadOnlyDictionary<double, double>(new Dictionary<double, double>()));
+
+        private static readonly MeterValue EmptyMeter = new MeterValue(0, 0.0, 0.0, 0.0, 0.0, TimeUnit.Seconds);
+        private static readonly BucketTimerValue EmptyTimer = new BucketTimerValue(EmptyMeter, EmptyHistogram, 0, TimeUnit.Milliseconds);
+
+        public static BucketTimerValue GetBucketTimerValue(this IProvideMetricValues valueService, string context, string metricName)
+        {
+            return valueService.GetForContext(context).BucketTimers.ValueFor(metricName);
+        }
+
+        public static BucketTimerValue GetBucketTimerValue(this IProvideMetricValues valueService, string context, string metricName, MetricTags tags)
+        {
+            return valueService.GetForContext(context).BucketTimers.ValueFor(tags.AsMetricName(metricName));
+        }
+
+        public static BucketTimerValue GetBucketValueOrDefault(this ITimer metric)
+        {
+            var implementation = metric as IBucketTimerMetric;
+            return implementation != null ? implementation.Value : EmptyTimer;
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/Extensions/MetricBucketHistogramFieldsExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/Extensions/MetricBucketHistogramFieldsExtensions.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="MetricHistogramFieldsExtensions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable CheckNamespace
+namespace App.Metrics
+    // ReSharper restore CheckNamespace
+{
+    public static class MetricBucketHistogramFieldsExtensions
+    {
+        public static void Exclude(this IDictionary<BucketHistogramFields, string> metricFields, params BucketHistogramFields[] fields)
+        {
+            if (!fields.Any())
+            {
+                metricFields.Clear();
+
+                return;
+            }
+
+            foreach (var key in fields)
+            {
+                if (metricFields.ContainsKey(key))
+                {
+                    metricFields.Remove(key);
+                }
+            }
+        }
+
+        public static void OnlyInclude(this IDictionary<BucketHistogramFields, string> metricFields, params BucketHistogramFields[] fields)
+        {
+            var histogram = new Dictionary<BucketHistogramFields, string>(metricFields);
+
+            foreach (var key in histogram.Keys)
+            {
+                if (!fields.Contains(key))
+                {
+                    metricFields.Remove(key);
+                }
+            }
+        }
+
+        public static void Set(this IDictionary<BucketHistogramFields, string> metricFields, BucketHistogramFields field, string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("metric field name cannot be null or empty", nameof(value));
+            }
+
+            if (metricFields.ContainsKey(field))
+            {
+                metricFields[field] = value;
+            }
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
+++ b/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -102,6 +103,17 @@ namespace App.Metrics.Filtering
 
         /// <inheritdoc />
         public bool IsTimerMatch(TimerValueSource timer)
+        {
+            if (_types != null && !_types.Contains(MetricType.Timer))
+            {
+                return false;
+            }
+
+            return IsMetricNameMatch(timer.Name) && IsTagMatch(timer.Tags);
+        }
+
+        /// <inheritdoc />
+        public bool IsBucketTimerMatch(BucketTimerValueSource timer)
         {
             if (_types != null && !_types.Contains(MetricType.Timer))
             {

--- a/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
+++ b/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -62,6 +63,17 @@ namespace App.Metrics.Filtering
 
         /// <inheritdoc />
         public bool IsHistogramMatch(HistogramValueSource histogram)
+        {
+            if (_types != null && !_types.Contains(MetricType.Histogram))
+            {
+                return false;
+            }
+
+            return IsMetricNameMatch(histogram.Name) && IsTagMatch(histogram.Tags);
+        }
+
+        /// <inheritdoc />
+        public bool IsBucketHistogramMatch(BucketHistogramValueSource histogram)
         {
             if (_types != null && !_types.Contains(MetricType.Histogram))
             {

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMeasureMetricsProvider.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMeasureMetricsProvider.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -28,6 +29,7 @@ namespace App.Metrics.Internal
             Counter = new DefaultCounterManager(buideFactory.Counter, registry);
             Gauge = new DefaultGaugeManager(buideFactory.Gauge, registry);
             Histogram = new DefaultHistogramManager(buideFactory.Histogram, registry);
+            BucketHistogram = new DefaultBucketHistogramManager(buideFactory.BucketHistogram, registry);
             Meter = new DefaultMeterManager(buideFactory.Meter, registry, clock);
             Timer = new DefaultTimerManager(buideFactory.Timer, registry, clock);
         }
@@ -43,6 +45,9 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IMeasureHistogramMetrics Histogram { get; }
+
+        /// <inheritdoc />
+        public IMeasureBucketHistogramMetrics BucketHistogram { get; }
 
         /// <inheritdoc />
         public IMeasureMeterMetrics Meter { get; }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMeasureMetricsProvider.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMeasureMetricsProvider.cs
@@ -4,6 +4,7 @@
 
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -32,6 +33,7 @@ namespace App.Metrics.Internal
             BucketHistogram = new DefaultBucketHistogramManager(buideFactory.BucketHistogram, registry);
             Meter = new DefaultMeterManager(buideFactory.Meter, registry, clock);
             Timer = new DefaultTimerManager(buideFactory.Timer, registry, clock);
+            BucketTimer = new DefaultBucketTimerManager(buideFactory.BucketTimer, registry, clock);
         }
 
         /// <inheritdoc />
@@ -54,5 +56,8 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IMeasureTimerMetrics Timer { get; }
+
+        /// <inheritdoc />
+        public IMeasureBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricRegistryManager.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricRegistryManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -24,6 +25,7 @@ namespace App.Metrics.Internal
         private readonly Func<IEnumerable<BucketHistogramValueSource>> _bucketHistograms;
         private readonly Func<IEnumerable<MeterValueSource>> _meters;
         private readonly Func<IEnumerable<TimerValueSource>> _timers;
+        private readonly Func<IEnumerable<BucketTimerValueSource>> _bucketTimers;
 
         public DefaultMetricRegistryManager(
             Func<IEnumerable<GaugeValueSource>> gauges,
@@ -32,6 +34,7 @@ namespace App.Metrics.Internal
             Func<IEnumerable<HistogramValueSource>> histograms,
             Func<IEnumerable<BucketHistogramValueSource>> bucketHistograms,
             Func<IEnumerable<TimerValueSource>> timers,
+            Func<IEnumerable<BucketTimerValueSource>> bucketTimers,
             Func<IEnumerable<ApdexValueSource>> apdexScores)
         {
             _gauges = gauges;
@@ -39,6 +42,7 @@ namespace App.Metrics.Internal
             _meters = meters;
             _histograms = histograms;
             _timers = timers;
+            _bucketTimers = bucketTimers;
             _apdexScores = apdexScores;
             _bucketHistograms = bucketHistograms;
         }
@@ -63,5 +67,8 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IEnumerable<TimerValueSource> Timers => _timers();
+
+        /// <inheritdoc />
+        public IEnumerable<BucketTimerValueSource> BucketTimers => _bucketTimers();
     }
 }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricRegistryManager.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricRegistryManager.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -20,6 +21,7 @@ namespace App.Metrics.Internal
         private readonly Func<IEnumerable<CounterValueSource>> _counters;
         private readonly Func<IEnumerable<GaugeValueSource>> _gauges;
         private readonly Func<IEnumerable<HistogramValueSource>> _histograms;
+        private readonly Func<IEnumerable<BucketHistogramValueSource>> _bucketHistograms;
         private readonly Func<IEnumerable<MeterValueSource>> _meters;
         private readonly Func<IEnumerable<TimerValueSource>> _timers;
 
@@ -28,6 +30,7 @@ namespace App.Metrics.Internal
             Func<IEnumerable<CounterValueSource>> counters,
             Func<IEnumerable<MeterValueSource>> meters,
             Func<IEnumerable<HistogramValueSource>> histograms,
+            Func<IEnumerable<BucketHistogramValueSource>> bucketHistograms,
             Func<IEnumerable<TimerValueSource>> timers,
             Func<IEnumerable<ApdexValueSource>> apdexScores)
         {
@@ -37,6 +40,7 @@ namespace App.Metrics.Internal
             _histograms = histograms;
             _timers = timers;
             _apdexScores = apdexScores;
+            _bucketHistograms = bucketHistograms;
         }
 
         /// <inheritdoc />
@@ -50,6 +54,9 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IEnumerable<HistogramValueSource> Histograms => _histograms();
+
+        /// <inheritdoc />
+        public IEnumerable<BucketHistogramValueSource> BucketHistograms => _bucketHistograms();
 
         /// <inheritdoc />
         public IEnumerable<MeterValueSource> Meters => _meters();

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsBuilderFactory.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsBuilderFactory.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -26,6 +27,7 @@ namespace App.Metrics.Internal
             Counter = new DefaultCounterBuilder();
             Gauge = new DefaultGaugeBuilder();
             Histogram = new DefaultHistogramBuilder(defaultSamplingReservoir);
+            BucketHistogram = new DefaultBucketHistogramBuilder();
             Meter = new DefaultMeterBuilder();
             Timer = new DefaultTimerBuilder(defaultSamplingReservoir);
         }
@@ -41,6 +43,9 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IBuildHistogramMetrics Histogram { get; }
+
+        /// <inheritdoc />
+        public IBuildBucketHistogramMetrics BucketHistogram { get; }
 
         /// <inheritdoc />
         public IBuildMeterMetrics Meter { get; }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsBuilderFactory.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsBuilderFactory.cs
@@ -4,6 +4,7 @@
 
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -30,6 +31,7 @@ namespace App.Metrics.Internal
             BucketHistogram = new DefaultBucketHistogramBuilder();
             Meter = new DefaultMeterBuilder();
             Timer = new DefaultTimerBuilder(defaultSamplingReservoir);
+            BucketTimer = new DefaultBucketTimerBuilder();
         }
 
         /// <inheritdoc />
@@ -52,5 +54,8 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IBuildTimerMetrics Timer { get; }
+
+        /// <inheritdoc />
+        public IBuildBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsProvider.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsProvider.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using App.Metrics.Apdex;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -28,6 +29,7 @@ namespace App.Metrics.Internal
             Histogram = new DefaultHistogramMetricProvider(builderFactory.Histogram, registry);
             Meter = new DefaultMeterMetricProvider(builderFactory.Meter, registry, clock);
             Timer = new DefaultTimerMetricProvider(builderFactory.Timer, registry, clock);
+            BucketTimer = new DefaultBucketTimerMetricProvider(builderFactory.BucketTimer, registry, clock);
         }
 
         /// <inheritdoc />
@@ -47,5 +49,8 @@ namespace App.Metrics.Internal
 
         /// <inheritdoc />
         public IProvideTimerMetrics Timer { get; }
+
+        /// <inheritdoc />
+        public IProvideBucketTimerMetrics BucketTimer { get; }
     }
 }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsRegistry.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsRegistry.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -194,6 +195,7 @@ namespace App.Metrics.Internal
                     g.DataProvider.Counters.ToArray(),
                     g.DataProvider.Meters.ToArray(),
                     g.DataProvider.Histograms.ToArray(),
+                    g.DataProvider.BucketHistograms.ToArray(),
                     g.DataProvider.Timers.ToArray(),
                     g.DataProvider.ApdexScores.ToArray()));
 
@@ -231,6 +233,37 @@ namespace App.Metrics.Internal
             var contextRegistry = _contexts.GetOrAdd(options.Context, _newContextRegistry);
 
             return contextRegistry.Histogram(options, tags, builder);
+        }
+
+        public IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            if (_nullMetricsRegistry.IsValueCreated)
+            {
+                return _nullMetricsRegistry.Value.BucketHistogram(options, builder);
+            }
+
+            EnsureContextLabel(options);
+
+            var contextRegistry = _contexts.GetOrAdd(options.Context, _newContextRegistry);
+
+            return contextRegistry.BucketHistogram(options, builder);
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            if (_nullMetricsRegistry.IsValueCreated)
+            {
+                return _nullMetricsRegistry.Value.BucketHistogram(options, tags, builder);
+            }
+
+            EnsureContextLabel(options);
+
+            var contextRegistry = _contexts.GetOrAdd(options.Context, _newContextRegistry);
+
+            return contextRegistry.BucketHistogram(options, tags, builder);
         }
 
         public IMeter Meter<T>(MeterOptions options, Func<T> builder)

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullBucketHistogram.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullBucketHistogram.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="NullHistogram.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using App.Metrics.BucketHistogram;
+
+namespace App.Metrics.Internal.NoOp
+{
+    [ExcludeFromCodeCoverage]
+    public struct NullBucketHistogram : IBucketHistogram
+    {
+        public void Reset() { }
+
+        public void Update(long value, string userValue) { }
+
+        public void Update(long value) { }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullBucketTimer.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullBucketTimer.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="NullTimer.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using App.Metrics.Timer;
+
+namespace App.Metrics.Internal.NoOp
+{
+    [ExcludeFromCodeCoverage]
+    public struct NullBucketTimer : ITimer
+    {
+        public long CurrentTime() { return 0; }
+
+        public long EndRecording() { return 0; }
+
+        public TimerContext NewContext(string userValue) { return new TimerContext(this, null); }
+
+        public void Record(long time, TimeUnit unit, string userValue) { }
+
+        public void Record(long time, TimeUnit unit) { }
+
+        public void Reset() { }
+
+        public long StartRecording() { return 0; }
+
+        public void Time(Action action, string userValue) { action(); }
+
+        public T Time<T>(Func<T> action, string userValue) { return action(); }
+
+        public void Time(Action action) { action(); }
+
+        public T Time<T>(Func<T> action) { return action(); }
+
+        TimerContext ITimer.NewContext() { return new TimerContext(this, null); }
+    }
+}

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsFilter.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsFilter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -28,6 +29,9 @@ namespace App.Metrics.Internal.NoOp
 
         /// <inheritdoc />
         public bool IsHistogramMatch(HistogramValueSource histogram) { return true; }
+
+        /// <inheritdoc />
+        public bool IsBucketHistogramMatch(BucketHistogramValueSource histogram) { return true; }
 
         /// <inheritdoc />
         public bool IsContextMatch(string context) { return true; }

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsFilter.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsFilter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -41,6 +42,9 @@ namespace App.Metrics.Internal.NoOp
 
         /// <inheritdoc />
         public bool IsTimerMatch(TimerValueSource timer) { return true; }
+
+        /// <inheritdoc />
+        public bool IsBucketTimerMatch(BucketTimerValueSource timer) { return true; }
 
         /// <inheritdoc />
         public IFilterMetrics WhereContext(Predicate<string> condition) { return this; }

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsRegistry.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsRegistry.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -82,6 +83,19 @@ namespace App.Metrics.Internal.NoOp
             return _histogramInstance;
         }
 
+        public IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            return _bucketHistogramInstance;
+        }
+
+        /// <inheritdoc />
+        public IBucketHistogram BucketHistogram<T>(BucketHistogramOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketHistogramMetric
+        {
+            return _bucketHistogramInstance;
+        }
+
         public IMeter Meter<T>(MeterOptions options, Func<T> builder)
             where T : IMeterMetric
         {
@@ -115,6 +129,7 @@ namespace App.Metrics.Internal.NoOp
         private readonly ICounter _counterInstance = new NullCounter();
         private readonly IGauge _gaugeInstance = new NullGauge();
         private readonly IHistogram _histogramInstance = new NullHistogram();
+        private readonly IBucketHistogram _bucketHistogramInstance = new NullBucketHistogram();
         private readonly IMeter _meterInstance = new NullMeter();
         private readonly ITimer _timerInstance = new NullTimer();
 #pragma warning restore SA1129

--- a/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsRegistry.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/NoOp/NullMetricsRegistry.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Filters;
 using App.Metrics.Gauge;
@@ -124,6 +125,19 @@ namespace App.Metrics.Internal.NoOp
             return _timerInstance;
         }
 
+        public ITimer BucketTimer<T>(BucketTimerOptions options, Func<T> builder)
+            where T : IBucketTimerMetric
+        {
+            return _bucketTimerInstance;
+        }
+
+        /// <inheritdoc />
+        public ITimer BucketTimer<T>(BucketTimerOptions options, MetricTags tags, Func<T> builder)
+            where T : IBucketTimerMetric
+        {
+            return _bucketTimerInstance;
+        }
+
 #pragma warning disable SA1129
         private readonly IApdex _apdexInstance = new NullApdex();
         private readonly ICounter _counterInstance = new NullCounter();
@@ -132,6 +146,7 @@ namespace App.Metrics.Internal.NoOp
         private readonly IBucketHistogram _bucketHistogramInstance = new NullBucketHistogram();
         private readonly IMeter _meterInstance = new NullMeter();
         private readonly ITimer _timerInstance = new NullTimer();
+        private readonly ITimer _bucketTimerInstance = new NullBucketTimer();
 #pragma warning restore SA1129
     }
 }

--- a/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="HistogramMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace App.Metrics.Formatters.Json
+{
+    /// <summary>
+    ///     <para>
+    ///         Bucket Histogram metric types track the count of a set of values. They allow you to measure the
+    ///         count of values per bucket
+    ///     </para>
+    /// </summary>
+    public sealed class BucketHistogramMetric : MetricBase
+    {
+        public long Count { get; set; }
+
+        public double Sum { get; set; }
+
+        public IReadOnlyDictionary<long, long> Buckets { get; set; }
+    }
+}

--- a/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
@@ -18,6 +18,6 @@ namespace App.Metrics.Formatters.Json
 
         public double Sum { get; set; }
 
-        public IReadOnlyDictionary<double, long> Buckets { get; set; }
+        public IReadOnlyDictionary<double, double> Buckets { get; set; }
     }
 }

--- a/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/BucketHistogramMetric.cs
@@ -18,6 +18,6 @@ namespace App.Metrics.Formatters.Json
 
         public double Sum { get; set; }
 
-        public IReadOnlyDictionary<long, long> Buckets { get; set; }
+        public IReadOnlyDictionary<double, long> Buckets { get; set; }
     }
 }

--- a/src/Core/src/App.Metrics.Formatters.Json/BucketTimerMetric.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/BucketTimerMetric.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="TimerMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace App.Metrics.Formatters.Json
+{
+    /// <summary>
+    ///     <para>
+    ///         Timer metric types are essentially a special case of <see cref="Histogram" />
+    ///     </para>
+    ///     <para>
+    ///         As well as providing a <see cref="Histogram" /> of the duration of a type of event, timers also provide a
+    ///         <see cref="MeterMetric" /> of the rate of the events occurrence.
+    ///     </para>
+    ///     <para>
+    ///         Like <see cref="Histogram" />s, timers also allow us to track user values, where for all user values provided
+    ///         the min, max and last user value values is recorded.
+    ///     </para>
+    /// </summary>
+    /// <seealso cref="MetricBase" />
+    public sealed class BucketTimerMetric : MetricBase
+    {
+        public long ActiveSessions { get; set; }
+
+        public long Count { get; set; }
+
+        public string DurationUnit { get; set; }
+
+        public BucketHistogramData Histogram { get; set; }
+
+        public RateData Rate { get; set; }
+
+        public string RateUnit { get; set; }
+
+        public sealed class BucketHistogramData
+        {
+            public IDictionary<double, double> Buckets { get; set; }
+
+            public double Sum { get; set; }
+        }
+
+        public sealed class RateData
+        {
+            public double FifteenMinuteRate { get; set; }
+
+            public double FiveMinuteRate { get; set; }
+
+            public double MeanRate { get; set; }
+
+            public double OneMinuteRate { get; set; }
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/HistogramValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/HistogramValueSourceSerializationExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Formatters.Json;
 
 // ReSharper disable CheckNamespace
@@ -40,12 +41,36 @@ namespace App.Metrics.Histogram
                 source.Tags.FromDictionary());
         }
 
+        public static BucketHistogramValueSource FromSerializableMetric(this BucketHistogramMetric source)
+        {
+            var histogramValue = new BucketHistogramValue(
+                source.Count,
+                source.Sum,
+                source.Buckets);
+
+            return new BucketHistogramValueSource(
+                source.Name,
+                ConstantValue.Provider(histogramValue),
+                source.Unit,
+                source.Tags.FromDictionary());
+        }
+
         public static IEnumerable<HistogramValueSource> FromSerializableMetric(this IEnumerable<HistogramMetric> source)
         {
             return source.Select(x => x.FromSerializableMetric());
         }
 
+        public static IEnumerable<BucketHistogramValueSource> FromSerializableMetric(this IEnumerable<BucketHistogramMetric> source)
+        {
+            return source.Select(x => x.FromSerializableMetric());
+        }
+
         public static IEnumerable<HistogramMetric> ToSerializableMetric(this IEnumerable<HistogramValueSource> source)
+        {
+            return source.Select(ToSerializableMetric);
+        }
+
+        public static IEnumerable<BucketHistogramMetric> ToSerializableMetric(this IEnumerable<BucketHistogramValueSource> source)
         {
             return source.Select(ToSerializableMetric);
         }
@@ -75,6 +100,19 @@ namespace App.Metrics.Histogram
                        StdDev = source.Value.StdDev,
                        Tags = source.Tags.ToDictionary()
                    };
+        }
+
+        public static BucketHistogramMetric ToSerializableMetric(this BucketHistogramValueSource source)
+        {
+            return new BucketHistogramMetric
+            {
+                Name = source.Name,
+                Count = source.Value.Count,
+                Sum = source.Value.Sum,
+                Unit = source.Unit.Name,
+                Buckets = source.Value.Buckets,
+                Tags = source.Tags.ToDictionary()
+            };
         }
     }
 }

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/MetricContextSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/MetricContextSerializationExtensions.cs
@@ -35,9 +35,10 @@ namespace App.Metrics.Formatters.Json
             var jsonHistograms = source.Histograms.FromSerializableMetric();
             var jsonBucketHistograms = source.BucketHistograms.FromSerializableMetric();
             var jsonTimers = source.Timers.FromSerializableMetric();
+            var jsonBucketTimers = source.BucketTimers.FromSerializableMetric();
             var jsonApdexScores = source.ApdexScores.FromSerializableMetric();
 
-            return new MetricsContextValueSource(source.Context, jsonGauges, jsonCounters, jsonMeters, jsonHistograms, jsonBucketHistograms, jsonTimers, jsonApdexScores);
+            return new MetricsContextValueSource(source.Context, jsonGauges, jsonCounters, jsonMeters, jsonHistograms, jsonBucketHistograms, jsonTimers, jsonBucketTimers, jsonApdexScores);
         }
 
         private static MetricsContext ToSerializableMetric(this MetricsContextValueSource source)
@@ -48,6 +49,7 @@ namespace App.Metrics.Formatters.Json
             var jsonHistograms = source.Histograms.ToSerializableMetric();
             var jsonBucketHistograms = source.BucketHistograms.ToSerializableMetric();
             var jsonTimers = source.Timers.ToSerializableMetric();
+            var jsonBucketTimers = source.BucketTimers.ToSerializableMetric();
             var jsonApdexScores = source.ApdexScores.ToSerializableMetric();
 
             return new MetricsContext
@@ -58,6 +60,7 @@ namespace App.Metrics.Formatters.Json
                        Histograms = jsonHistograms,
                        BucketHistograms = jsonBucketHistograms,
                        Timers = jsonTimers,
+                       BucketTimers = jsonBucketTimers,
                        Context = source.Context,
                        ApdexScores = jsonApdexScores
                    };

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/MetricContextSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/MetricContextSerializationExtensions.cs
@@ -33,10 +33,11 @@ namespace App.Metrics.Formatters.Json
             var jsonMeters = source.Meters.FromSerializableMetric();
             var jsonGauges = source.Gauges.FromSerializableMetric();
             var jsonHistograms = source.Histograms.FromSerializableMetric();
+            var jsonBucketHistograms = source.BucketHistograms.FromSerializableMetric();
             var jsonTimers = source.Timers.FromSerializableMetric();
             var jsonApdexScores = source.ApdexScores.FromSerializableMetric();
 
-            return new MetricsContextValueSource(source.Context, jsonGauges, jsonCounters, jsonMeters, jsonHistograms, jsonTimers, jsonApdexScores);
+            return new MetricsContextValueSource(source.Context, jsonGauges, jsonCounters, jsonMeters, jsonHistograms, jsonBucketHistograms, jsonTimers, jsonApdexScores);
         }
 
         private static MetricsContext ToSerializableMetric(this MetricsContextValueSource source)
@@ -45,6 +46,7 @@ namespace App.Metrics.Formatters.Json
             var jsonMeters = source.Meters.ToSerializableMetric();
             var jsonGauges = source.Gauges.ToSerializableMetric();
             var jsonHistograms = source.Histograms.ToSerializableMetric();
+            var jsonBucketHistograms = source.BucketHistograms.ToSerializableMetric();
             var jsonTimers = source.Timers.ToSerializableMetric();
             var jsonApdexScores = source.ApdexScores.ToSerializableMetric();
 
@@ -54,6 +56,7 @@ namespace App.Metrics.Formatters.Json
                        Meters = jsonMeters,
                        Gauges = jsonGauges,
                        Histograms = jsonHistograms,
+                       BucketHistograms = jsonBucketHistograms,
                        Timers = jsonTimers,
                        Context = source.Context,
                        ApdexScores = jsonApdexScores

--- a/src/Core/src/App.Metrics.Formatters.Json/MetricsContext.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/MetricsContext.cs
@@ -30,5 +30,7 @@ namespace App.Metrics.Formatters.Json
         public IEnumerable<MeterMetric> Meters { get; set; } = Enumerable.Empty<MeterMetric>();
 
         public IEnumerable<TimerMetric> Timers { get; set; } = Enumerable.Empty<TimerMetric>();
+
+        public IEnumerable<BucketTimerMetric> BucketTimers { get; set; } = Enumerable.Empty<BucketTimerMetric>();
     }
 }

--- a/src/Core/src/App.Metrics.Formatters.Json/MetricsContext.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/MetricsContext.cs
@@ -25,6 +25,8 @@ namespace App.Metrics.Formatters.Json
 
         public IEnumerable<HistogramMetric> Histograms { get; set; } = Enumerable.Empty<HistogramMetric>();
 
+        public IEnumerable<BucketHistogramMetric> BucketHistograms { get; set; } = Enumerable.Empty<BucketHistogramMetric>();
+
         public IEnumerable<MeterMetric> Meters { get; set; } = Enumerable.Empty<MeterMetric>();
 
         public IEnumerable<TimerMetric> Timers { get; set; } = Enumerable.Empty<TimerMetric>();

--- a/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
@@ -91,10 +91,10 @@ namespace App.Metrics.Facts.BucketHistogram
                 options,
                 i => _histogram.Update(i));
 
-            _histogram.Value.Buckets[10].Should().Be(Enumerable.Range(1, 10).Sum());
-            _histogram.Value.Buckets[100].Should().Be(Enumerable.Range(11, 90).Sum());
-            _histogram.Value.Buckets[1000].Should().Be(Enumerable.Range(101, 900).Sum());
-            _histogram.Value.Buckets[double.PositiveInfinity].Should().Be(Enumerable.Range(1001, 9000).Sum());
+            _histogram.Value.Buckets[10].Should().Be(Enumerable.Range(1, 10).Count());
+            _histogram.Value.Buckets[100].Should().Be(Enumerable.Range(11, 90).Count());
+            _histogram.Value.Buckets[1000].Should().Be(Enumerable.Range(101, 900).Count());
+            _histogram.Value.Buckets[double.PositiveInfinity].Should().Be(Enumerable.Range(1001, 9000).Count());
         }
 
         [Fact]

--- a/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
@@ -1,0 +1,108 @@
+﻿// <copyright file="HistogramMetricTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using App.Metrics.BucketHistogram;
+using App.Metrics.Facts.TestHelpers;
+using App.Metrics.Histogram;
+using App.Metrics.ReservoirSampling.ExponentialDecay;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Facts.BucketHistogram
+{
+    public class BucketHistogramMetricTests
+    {
+        private readonly DefaultBucketHistogramMetric _histogram;
+
+        public BucketHistogramMetricTests() { _histogram = new DefaultBucketHistogramMetric(new[] { 10L, 100L, 1000L }); }
+
+        [Fact]
+        public void Can_count()
+        {
+            _histogram.Update(1L);
+            _histogram.Value.Count.Should().Be(1);
+            _histogram.Update(1L);
+            _histogram.Value.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void Can_reset()
+        {
+            _histogram.Update(10L);
+            _histogram.Update(100L);
+            _histogram.Update(1000L);
+            _histogram.Update(10000L);
+
+            _histogram.Value.Count.Should().NotBe(0);
+            _histogram.Value.Sum.Should().NotBe(0);
+            _histogram.Value.Buckets[10].Should().NotBe(0);
+            _histogram.Value.Buckets[100].Should().NotBe(0);
+            _histogram.Value.Buckets[1000].Should().NotBe(0);
+            _histogram.Value.Buckets[long.MaxValue].Should().NotBe(0);
+
+            _histogram.Reset();
+
+            _histogram.Value.Count.Should().Be(0);
+            _histogram.Value.Sum.Should().Be(0);
+            _histogram.Value.Buckets[10].Should().Be(0);
+            _histogram.Value.Buckets[100].Should().Be(0);
+            _histogram.Value.Buckets[1000].Should().Be(0);
+            _histogram.Value.Buckets[long.MaxValue].Should().Be(0);
+        }
+
+        [Fact]
+        public void Records_lifetime_sum_of_observed_values()
+        {
+            double sum = Enumerable.Range(1, 10000).Sum();
+            var options = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+            Parallel.For(
+                1,
+                10001,
+                options,
+                i => _histogram.Update(i));
+
+            _histogram.Value.Sum.Should().Be(sum);
+        }
+
+        [Fact]
+        public void Records_lifetime_count_of_observed_values()
+        {
+            var options = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+            Parallel.For(
+                1,
+                10001,
+                options,
+                i => _histogram.Update(i));
+
+            _histogram.Value.Count.Should().Be(10000L);
+        }
+
+        [Fact]
+        public void Records_lifetime_count_of_each_bucket_values()
+        {
+            var options = new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount };
+            Parallel.For(
+                1,
+                10001,
+                options,
+                i => _histogram.Update(i));
+
+            _histogram.Value.Buckets[10].Should().Be(Enumerable.Range(1, 10).Sum());
+            _histogram.Value.Buckets[100].Should().Be(Enumerable.Range(11, 90).Sum());
+            _histogram.Value.Buckets[1000].Should().Be(Enumerable.Range(101, 900).Sum());
+            _histogram.Value.Buckets[long.MaxValue].Should().Be(Enumerable.Range(1001, 9000).Sum());
+        }
+
+        [Fact]
+        public void Returns_empty_histogram_if_not_histogram_metric()
+        {
+            var histogram = new CustomHistogram();
+            var value = histogram.GetValueOrDefault();
+            value.Should().NotBeNull();
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketHistogram/BucketHistogramMetricTests.cs
@@ -18,7 +18,7 @@ namespace App.Metrics.Facts.BucketHistogram
     {
         private readonly DefaultBucketHistogramMetric _histogram;
 
-        public BucketHistogramMetricTests() { _histogram = new DefaultBucketHistogramMetric(new[] { 10L, 100L, 1000L }); }
+        public BucketHistogramMetricTests() { _histogram = new DefaultBucketHistogramMetric(new[] { 10d, 100d, 1000d }); }
 
         [Fact]
         public void Can_count()
@@ -42,7 +42,7 @@ namespace App.Metrics.Facts.BucketHistogram
             _histogram.Value.Buckets[10].Should().NotBe(0);
             _histogram.Value.Buckets[100].Should().NotBe(0);
             _histogram.Value.Buckets[1000].Should().NotBe(0);
-            _histogram.Value.Buckets[long.MaxValue].Should().NotBe(0);
+            _histogram.Value.Buckets[double.PositiveInfinity].Should().NotBe(0);
 
             _histogram.Reset();
 
@@ -51,7 +51,7 @@ namespace App.Metrics.Facts.BucketHistogram
             _histogram.Value.Buckets[10].Should().Be(0);
             _histogram.Value.Buckets[100].Should().Be(0);
             _histogram.Value.Buckets[1000].Should().Be(0);
-            _histogram.Value.Buckets[long.MaxValue].Should().Be(0);
+            _histogram.Value.Buckets[double.PositiveInfinity].Should().Be(0);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace App.Metrics.Facts.BucketHistogram
             _histogram.Value.Buckets[10].Should().Be(Enumerable.Range(1, 10).Sum());
             _histogram.Value.Buckets[100].Should().Be(Enumerable.Range(11, 90).Sum());
             _histogram.Value.Buckets[1000].Should().Be(Enumerable.Range(101, 900).Sum());
-            _histogram.Value.Buckets[long.MaxValue].Should().Be(Enumerable.Range(1001, 9000).Sum());
+            _histogram.Value.Buckets[double.PositiveInfinity].Should().Be(Enumerable.Range(1001, 9000).Sum());
         }
 
         [Fact]

--- a/src/Core/test/App.Metrics.Facts/BucketTimer/BucketTimerMetricTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketTimer/BucketTimerMetricTests.cs
@@ -26,7 +26,8 @@ namespace App.Metrics.Facts.BucketTimer
             _timer = new DefaultBucketTimerMetric(
                 new DefaultBucketHistogramMetric(new[] { 100000000d, 300000000 }),
                 new DefaultMeterMetric(_clock),
-                _clock);
+                _clock,
+                TimeUnit.Nanoseconds);
         }
 
         [Fact]

--- a/src/Core/test/App.Metrics.Facts/BucketTimer/BucketTimerMetricTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketTimer/BucketTimerMetricTests.cs
@@ -1,0 +1,145 @@
+﻿// <copyright file="TimerMetricTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
+using App.Metrics.Facts.TestHelpers;
+using App.Metrics.FactsCommon;
+using App.Metrics.Histogram;
+using App.Metrics.Meter;
+using App.Metrics.ReservoirSampling.ExponentialDecay;
+using App.Metrics.Timer;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Facts.BucketTimer
+{
+    public class BucketTimerMetricTests
+    {
+        private readonly IClock _clock = new TestClock();
+        private readonly DefaultBucketTimerMetric _timer;
+
+        public BucketTimerMetricTests()
+        {
+            _timer = new DefaultBucketTimerMetric(
+                new DefaultBucketHistogramMetric(new[] { 100000000d, 300000000 }),
+                new DefaultMeterMetric(_clock),
+                _clock);
+        }
+
+        [Fact]
+        public void Can_count()
+        {
+            _timer.Value.Rate.Count.Should().Be(0);
+            using (_timer.NewContext())
+            {
+            }
+
+            _timer.Value.Rate.Count.Should().Be(1);
+            using (_timer.NewContext())
+            {
+            }
+
+            _timer.Value.Rate.Count.Should().Be(2);
+            _timer.Time(() => { });
+            _timer.Value.Rate.Count.Should().Be(3);
+            _timer.Time(() => 1);
+            _timer.Value.Rate.Count.Should().Be(4);
+        }
+
+        [Fact]
+        public void Can_reset()
+        {
+            using (_timer.NewContext())
+            {
+                _clock.Advance(TimeUnit.Milliseconds, 100);
+            }
+
+            _timer.Value.Rate.Count.Should().NotBe(0);
+            _timer.Value.Histogram.Count.Should().NotBe(0);
+
+            _timer.Reset();
+
+            _timer.Value.Rate.Count.Should().Be(0);
+            _timer.Value.Histogram.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void Can_track_time()
+        {
+            using (_timer.NewContext())
+            {
+                _clock.Advance(TimeUnit.Milliseconds, 100);
+            }
+
+            _timer.Value.Histogram.Count.Should().Be(1);
+            _timer.Value.Histogram.Buckets[100000000].Should().Be(1);
+
+            using (_timer.NewContext())
+            {
+                _clock.Advance(TimeUnit.Milliseconds, 300);
+            }
+
+            _timer.Value.Histogram.Count.Should().Be(2);
+            _timer.Value.Histogram.Buckets[100000000].Should().Be(1);
+            _timer.Value.Histogram.Buckets[300000000].Should().Be(1);
+        }
+
+        [Fact]
+        public void Context_records_time_only_on_first_dispose()
+        {
+            var context = _timer.NewContext();
+            _clock.Advance(TimeUnit.Milliseconds, 100);
+            context.Dispose(); // passing the structure to using() creates a copy
+            _clock.Advance(TimeUnit.Milliseconds, 100);
+            context.Dispose();
+
+            _timer.Value.Histogram.Count.Should().Be(1);
+            _timer.Value.Histogram.Buckets[100000000].Should().Be(1);
+        }
+
+        [Fact]
+        public void Context_reports_elapsed_time()
+        {
+            using (var context = _timer.NewContext())
+            {
+                _clock.Advance(TimeUnit.Milliseconds, 100);
+                context.Elapsed.TotalMilliseconds.Should().Be(100);
+            }
+        }
+
+        [Fact]
+        public void Counts_even_when_action_throws()
+        {
+            Action action = () => _timer.Time(() => throw new InvalidOperationException());
+
+            action.Should().Throw<InvalidOperationException>();
+
+            _timer.Value.Rate.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Records_active_sessions()
+        {
+            _timer.Value.ActiveSessions.Should().Be(0);
+            var context1 = _timer.NewContext();
+            _timer.Value.ActiveSessions.Should().Be(1);
+            var context2 = _timer.NewContext();
+            _timer.Value.ActiveSessions.Should().Be(2);
+            context1.Dispose();
+            _timer.Value.ActiveSessions.Should().Be(1);
+            context2.Dispose();
+            _timer.Value.ActiveSessions.Should().Be(0);
+        }
+
+        [Fact]
+        public void Returns_empty_timer_if_not_timer_metric()
+        {
+            var timer = new CustomTimer();
+            var value = timer.GetValueOrDefault();
+            value.Should().NotBeNull();
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.Facts/BucketTimer/CustomMetricsTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketTimer/CustomMetricsTests.cs
@@ -30,7 +30,8 @@ namespace App.Metrics.Facts.BucketTimer
             var timerOptions = new BucketTimerOptions
                                {
                                    Name = "custom",
-                                   MeasurementUnit = Unit.Calls
+                                   MeasurementUnit = Unit.Calls,
+                                   DurationUnit = TimeUnit.Nanoseconds
                                };
 
             var timer = _fixture.Metrics.Provider.BucketTimer.WithHistogram(timerOptions, () => histogram);

--- a/src/Core/test/App.Metrics.Facts/BucketTimer/CustomMetricsTests.cs
+++ b/src/Core/test/App.Metrics.Facts/BucketTimer/CustomMetricsTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="CustomMetricsTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using App.Metrics.BucketTimer;
+using App.Metrics.Facts.TestHelpers;
+using App.Metrics.FactsCommon.Fixtures;
+using App.Metrics.Timer;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Facts.BucketTimer
+{
+    public class CustomMetricsTests : IDisposable
+    {
+        private readonly MetricsFixture _fixture;
+
+        public CustomMetricsTests()
+        {
+            // DEVNOTE: Don't want Metrics to be shared between tests
+            _fixture = new MetricsFixture();
+        }
+
+        [Fact]
+        public void Can_register_timer_with_custom_histogram()
+        {
+            var histogram = new CustomBucketHistogramMetric();
+            var timerOptions = new BucketTimerOptions
+                               {
+                                   Name = "custom",
+                                   MeasurementUnit = Unit.Calls
+                               };
+
+            var timer = _fixture.Metrics.Provider.BucketTimer.WithHistogram(timerOptions, () => histogram);
+
+            timer.Record(10L, TimeUnit.Nanoseconds);
+
+            histogram.Size.Should().Be(1);
+            histogram.Values.Single().Should().Be(10L);
+        }
+
+        public void Dispose() { _fixture?.Dispose(); }
+    }
+}

--- a/src/Core/test/App.Metrics.Facts/Managers/DefaultBucketHistogramManagerTests.cs
+++ b/src/Core/test/App.Metrics.Facts/Managers/DefaultBucketHistogramManagerTests.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="DefaultHistogramManagerTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using App.Metrics.BucketHistogram;
+using App.Metrics.Facts.Fixtures;
+using App.Metrics.Histogram;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Facts.Managers
+{
+    public class DefaultBucketHistogramManagerTests : IClassFixture<MetricCoreTestFixture>
+    {
+        private readonly string _context;
+        private readonly MetricCoreTestFixture _fixture;
+        private readonly IMeasureBucketHistogramMetrics _manager;
+
+        public DefaultBucketHistogramManagerTests(MetricCoreTestFixture fixture)
+        {
+            _fixture = fixture;
+            _manager = _fixture.Managers.BucketHistogram;
+            _context = _fixture.Context;
+        }
+
+        [Fact]
+        public void Can_update()
+        {
+            var metricName = "test_update_histogram";
+            var options = new BucketHistogramOptions { Name = metricName };
+
+            _manager.Update(options, 2L);
+
+            _fixture.Snapshot.GetBucketHistogramValue(_context, metricName).Sum.Should().Be(2L);
+            _fixture.Snapshot.GetBucketHistogramValue(_context, metricName).Count.Should().Be(1L);
+        }
+
+        [Fact]
+        public void Can_update_multidimensional()
+        {
+            var metricName = "test_update_histogram_multi";
+            var options = new BucketHistogramOptions { Name = metricName };
+
+            _manager.Update(options, _fixture.Tags[0], 2L);
+            _manager.Update(options, _fixture.Tags[1], 4L);
+
+            _fixture.Snapshot.GetBucketHistogramValue(_context, _fixture.Tags[0].AsMetricName(metricName)).Sum.Should().Be(2L);
+            _fixture.Snapshot.GetBucketHistogramValue(_context, _fixture.Tags[0].AsMetricName(metricName)).Count.Should().Be(1L);
+            _fixture.Snapshot.GetBucketHistogramValue(_context, _fixture.Tags[1].AsMetricName(metricName)).Sum.Should().Be(4L);
+            _fixture.Snapshot.GetBucketHistogramValue(_context, _fixture.Tags[1].AsMetricName(metricName)).Count.Should().Be(1L);
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.Facts/TestHelpers/CustomBucketHistogramMetric.cs
+++ b/src/Core/test/App.Metrics.Facts/TestHelpers/CustomBucketHistogramMetric.cs
@@ -1,0 +1,41 @@
+// <copyright file="CustomHistogramMetric.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using App.Metrics.BucketHistogram;
+
+namespace App.Metrics.Facts.TestHelpers
+{
+    public class CustomBucketHistogramMetric : IBucketHistogramMetric
+    {
+        private bool _disposed;
+        private readonly List<long> _values = new List<long>();
+
+        public long Count => _values.Count;
+
+        public int Size => _values.Count;
+
+        public IEnumerable<long> Values => _values;
+
+
+        public BucketHistogramValue Value => new BucketHistogramValue(Count, 0, new Dictionary<double, double>());
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+            }
+
+            _disposed = true;
+        }
+
+        public BucketHistogramValue GetValue(bool resetMetric = false) { return Value; }
+
+        public void Reset() { _values.Clear(); }
+
+        public void Update(long value, string userValue) { _values.Add(value); }
+
+        public void Update(long value) { _values.Add(value); }
+    }
+}

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/App.Metrics.Formatters.Json.Facts.csproj
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/App.Metrics.Formatters.Json.Facts.csproj
@@ -1,11 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <None Remove="JsonFiles\buckethistogram.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="JsonFiles\apdex.json" />
     <EmbeddedResource Include="JsonFiles\counter_reset.json" />
     <EmbeddedResource Include="JsonFiles\counter.json" />
     <EmbeddedResource Include="JsonFiles\env.json" />
     <EmbeddedResource Include="JsonFiles\gauge.json" />
+    <EmbeddedResource Include="JsonFiles\buckethistogram.json" />
     <EmbeddedResource Include="JsonFiles\histogram.json" />
     <EmbeddedResource Include="JsonFiles\meter.json" />
     <EmbeddedResource Include="JsonFiles\meter_with_items.json" />

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/App.Metrics.Formatters.Json.Facts.csproj
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/App.Metrics.Formatters.Json.Facts.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <None Remove="JsonFiles\buckethistogram.json" />
+    <None Remove="JsonFiles\buckettimer.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
     <EmbeddedResource Include="JsonFiles\meter.json" />
     <EmbeddedResource Include="JsonFiles\meter_with_items.json" />
     <EmbeddedResource Include="JsonFiles\metricdata_single_context.json" />
+    <EmbeddedResource Include="JsonFiles\buckettimer.json" />
     <EmbeddedResource Include="JsonFiles\timer.json" />
   </ItemGroup>
 

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/BucketHistogramFormattingTests.cs
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/BucketHistogramFormattingTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="HistogramFormattingTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using App.Metrics.Formatters.Json.Facts.Helpers;
+using App.Metrics.Formatters.Json.Facts.TestFixtures;
+using FluentAssertions;
+using FluentAssertions.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace App.Metrics.Formatters.Json.Facts
+{
+    public class BucketHistogramFormattingTests : IClassFixture<MetricProviderTestFixture>
+    {
+        private readonly MetricsDataValueSource _metrics;
+        private readonly ITestOutputHelper _output;
+        private readonly IMetricsOutputFormatter _formatter;
+
+        public BucketHistogramFormattingTests(ITestOutputHelper output, MetricProviderTestFixture fixture)
+        {
+            _output = output;
+            _formatter = new MetricsJsonOutputFormatter();
+            _metrics = fixture.BucketHistogramContext;
+        }
+
+        [Fact]
+        public async Task Produces_expected_json()
+        {
+            // Arrange
+            JToken result;
+            var expected = MetricType.BucketHistogram.SampleJson();
+
+            // Act
+            using (var stream = new MemoryStream())
+            {
+                await _formatter.WriteAsync(stream, _metrics);
+
+                result = Encoding.UTF8.GetString(stream.ToArray()).ParseAsJson();
+            }
+
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task Produces_valid_Json()
+        {
+            // Arrange
+            string result;
+
+            // Act
+            using (var stream = new MemoryStream())
+            {
+                await _formatter.WriteAsync(stream, _metrics);
+
+                result = Encoding.UTF8.GetString(stream.ToArray());
+            }
+
+            _output.WriteLine("Json Metrics Data: {0}", result);
+
+            // Assert
+            Action action = () => JToken.Parse(result);
+            action.Should().NotThrow<Exception>();
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/BucketTimerFormattingTests.cs
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/BucketTimerFormattingTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="TimerFormattingTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using App.Metrics.Formatters.Json.Facts.Helpers;
+using App.Metrics.Formatters.Json.Facts.TestFixtures;
+using FluentAssertions;
+using FluentAssertions.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace App.Metrics.Formatters.Json.Facts
+{
+    public class BucketTimerFormattingTests : IClassFixture<MetricProviderTestFixture>
+    {
+        private readonly MetricsDataValueSource _metrics;
+        private readonly ITestOutputHelper _output;
+        private readonly IMetricsOutputFormatter _formatter;
+
+        public BucketTimerFormattingTests(ITestOutputHelper output, MetricProviderTestFixture fixture)
+        {
+            _output = output;
+            _formatter = new MetricsJsonOutputFormatter();
+            _metrics = fixture.BucketTimerContext;
+        }
+
+        [Fact]
+        public async Task Produces_expected_json()
+        {
+            // Arrange
+            JToken result;
+            var expected = MetricType.BucketTimer.SampleJson();
+
+            // Act
+            using (var stream = new MemoryStream())
+            {
+                await _formatter.WriteAsync(stream, _metrics);
+
+                result = Encoding.UTF8.GetString(stream.ToArray()).ParseAsJson();
+            }
+
+            // Assert
+            result.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task Produces_valid_Json()
+        {
+            // Arrange
+            string result;
+
+            // Act
+            using (var stream = new MemoryStream())
+            {
+                await _formatter.WriteAsync(stream, _metrics);
+
+                result = Encoding.UTF8.GetString(stream.ToArray());
+            }
+
+            _output.WriteLine("Json Metrics Data: {0}", result);
+
+            // Assert
+            Action action = () => JToken.Parse(result);
+            action.Should().NotThrow<Exception>();
+        }
+    }
+}

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/apdex.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/apdex.json
@@ -22,7 +22,8 @@
       "histograms": [],
       "bucketHistograms": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/apdex.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/apdex.json
@@ -20,6 +20,7 @@
       "counters": [],
       "gauges": [],
       "histograms": [],
+      "bucketHistograms": [],
       "meters": [],
       "timers": []
     }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckethistogram.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckethistogram.json
@@ -5,19 +5,23 @@
       "context": "context_one",
       "apdexScores": [],
       "counters": [],
-      "gauges": [
+      "histograms": [],
+      "bucketHistograms": [
         {
-          "name": "test_gauge",
-          "unit": "calls",
-          "value": 0.5,
+          "name": "test_bucket_histogram",
+          "unit": "items",
+          "count": 1,
+          "sum": 1.0,
+          "buckets": {
+            "1": 1
+          },
           "tags": {
             "host": "server1",
             "env": "staging"
           }
         }
       ],
-      "histograms": [],
-      "bucketHistograms": [],
+      "gauges": [],
       "meters": [],
       "timers": []
     }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckethistogram.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckethistogram.json
@@ -5,6 +5,7 @@
       "context": "context_one",
       "apdexScores": [],
       "counters": [],
+      "gauges": [],
       "histograms": [],
       "bucketHistograms": [
         {
@@ -13,7 +14,7 @@
           "count": 1,
           "sum": 1.0,
           "buckets": {
-            "1": 1
+            "1": 1.0
           },
           "tags": {
             "host": "server1",
@@ -21,9 +22,9 @@
           }
         }
       ],
-      "gauges": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckettimer.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckettimer.json
@@ -9,29 +9,18 @@
       "histograms": [],
       "bucketHistograms": [],
       "meters": [],
-      "timers": [
+      "timers": [],
+      "bucketTimers": [
         {
-          "name": "test_timer",
+          "name": "test_bucket_timer",
           "unit": "req",
           "activeSessions": 0,
           "count": 5,
           "durationUnit": "ms",
           "histogram": {
-            "lastUserValue": "3",
-            "lastValue": 2E-06,
-            "max": 4E-06,
-            "maxUserValue": "5",
-            "mean": 6E-06,
-            "median": 9.9999999999999991E-06,
-            "min": 7E-06,
-            "minUserValue": "8",
-            "percentile75": 1.1E-05,
-            "percentile95": 1.2E-05,
-            "percentile98": 1.3E-05,
-            "percentile99": 1.4E-05,
-            "percentile999": 1.4999999999999999E-05,
-            "sampleSize": 16,
-            "stdDev": 9E-06,
+            "buckets": {
+              "1": 1E-06
+            },
             "sum": 1E-06
           },
           "rate": {
@@ -46,8 +35,7 @@
             "env": "staging"
           }
         }
-      ],
-      "bucketTimers": []
+      ]
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckettimer.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/buckettimer.json
@@ -19,9 +19,9 @@
           "durationUnit": "ms",
           "histogram": {
             "buckets": {
-              "1": 1E-06
+              "1": 1.0
             },
-            "sum": 1E-06
+            "sum": 1.0
           },
           "rate": {
             "fifteenMinuteRate": 4.0,

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter.json
@@ -36,7 +36,8 @@
       "histograms": [],
       "bucketHistograms": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter.json
@@ -31,9 +31,10 @@
             "env": "staging"
           }
         }
-      ],      
+      ],
       "gauges": [],
       "histograms": [],
+      "bucketHistograms": [],
       "meters": [],
       "timers": []
     }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter_reset.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter_reset.json
@@ -36,7 +36,8 @@
       "histograms": [],
       "bucketHistograms": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter_reset.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/counter_reset.json
@@ -31,9 +31,10 @@
             "env": "staging"
           }
         }
-      ],      
+      ],
       "gauges": [],
       "histograms": [],
+      "bucketHistograms": [],
       "meters": [],
       "timers": []
     }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/gauge.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/gauge.json
@@ -19,7 +19,8 @@
       "histograms": [],
       "bucketHistograms": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/histogram.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/histogram.json
@@ -35,7 +35,8 @@
       "bucketHistograms": [],
       "gauges": [],
       "meters": [],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/histogram.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/histogram.json
@@ -32,6 +32,7 @@
           }
         }
       ],
+      "bucketHistograms": [],
       "gauges": [],
       "meters": [],
       "timers": []

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/meter.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/meter.json
@@ -7,6 +7,7 @@
       "counters": [],
       "gauges": [],
       "histograms": [],
+      "bucketHistograms": [],
       "meters": [
         {
           "name": "test_meter",

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/meter.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/meter.json
@@ -35,7 +35,8 @@
           }
         }
       ],
-      "timers": []
+      "timers": [],
+      "bucketTimers": []
     }
   ]
 }

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
@@ -83,6 +83,21 @@
           }
         }
       ],
+      "bucketHistograms": [
+        {
+          "name": "test_bucket_histogram",
+          "unit": "items",
+          "count": 1,
+          "sum": 1.0,
+          "buckets": {
+            "1": 1
+          },
+          "tags": {
+            "host": "server1",
+            "env": "staging"
+          }
+        }
+      ],
       "meters": [
         {
           "name": "test_meter",

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
@@ -172,9 +172,9 @@
           "durationUnit": "ms",
           "histogram": {
             "buckets": {
-              "1": 1E-06
+              "1": 1.0
             },
-            "sum": 1E-06
+            "sum": 1.0
           },
           "rate": {
             "fifteenMinuteRate": 4.0,

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/metricdata_single_context.json
@@ -90,7 +90,7 @@
           "count": 1,
           "sum": 1.0,
           "buckets": {
-            "1": 1
+            "1": 1.0
           },
           "tags": {
             "host": "server1",
@@ -149,6 +149,32 @@
             "percentile999": 1.4999999999999999E-05,
             "sampleSize": 16,
             "stdDev": 9E-06
+          },
+          "rate": {
+            "fifteenMinuteRate": 4.0,
+            "fiveMinuteRate": 3.0,
+            "meanRate": 1.0,
+            "oneMinuteRate": 2.0
+          },
+          "rateUnit": "s",
+          "tags": {
+            "host": "server1",
+            "env": "staging"
+          }
+        }
+      ],
+      "bucketTimers": [
+        {
+          "name": "test_bucket_timer",
+          "unit": "req",
+          "activeSessions": 0,
+          "count": 5,
+          "durationUnit": "ms",
+          "histogram": {
+            "buckets": {
+              "1": 1E-06
+            },
+            "sum": 1E-06
           },
           "rate": {
             "fifteenMinuteRate": 4.0,

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/timer.json
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/JsonFiles/timer.json
@@ -7,6 +7,7 @@
       "counters": [],
       "gauges": [],
       "histograms": [],
+      "bucketHistograms": [],
       "meters": [],
       "timers": [
         {

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.FactsCommon;
 using App.Metrics.Gauge;
@@ -29,15 +30,17 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
             Timers = SetupTimers();
             ApdexScores = SetupApdexScores();
             Histograms = SetupHistograms();
+            BucketHistograms = SetupBucketHistograms();
             ContextOne = SetupContextOne();
             DataWithOneContext = SetupMetricsData(new[] { ContextOne });
-            ApdexContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), ApdexScores) });
-            CounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Counters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            ResetCounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), ResetCounters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            GaugeContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Gauges, Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            MeterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Meters, Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            TimerContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Timers, Enumerable.Empty<ApdexValueSource>()) });
-            HistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Histograms, Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            ApdexContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), ApdexScores) });
+            CounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Counters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            ResetCounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), ResetCounters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            GaugeContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Gauges, Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            MeterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Meters, Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            TimerContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Timers, Enumerable.Empty<ApdexValueSource>()) });
+            HistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Histograms, Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            BucketHistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), BucketHistograms, Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
         }
 
         public string ApdexNameDefault { get; } = "test_apdex";
@@ -64,6 +67,8 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         public MetricsDataValueSource HistogramContext { get; }
 
+        public MetricsDataValueSource BucketHistogramContext { get; }
+
         public MetricsDataValueSource ApdexContext { get; }
 
         public EnvironmentInfo Env => new EnvironmentInfo(
@@ -85,7 +90,11 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         public string HistogramNameDefault { get; } = "test_histogram";
 
+        public string BucketHistogramNameDefault { get; } = "test_bucket_histogram";
+
         public IEnumerable<HistogramValueSource> Histograms { get; }
+
+        public IEnumerable<BucketHistogramValueSource> BucketHistograms { get; }
 
         public string MeterNameDefault { get; } = "test_meter";
 
@@ -111,7 +120,7 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         private MetricsContextValueSource SetupContextOne()
         {
-            return new MetricsContextValueSource("context_one", Gauges, Counters, Meters, Histograms, Timers, ApdexScores);
+            return new MetricsContextValueSource("context_one", Gauges, Counters, Meters, Histograms, BucketHistograms, Timers, ApdexScores);
         }
 
         private IEnumerable<CounterValueSource> SetupCounters(bool resetOnReporting)
@@ -139,6 +148,15 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
             return new[] { histogram };
         }
+
+        private IEnumerable<BucketHistogramValueSource> SetupBucketHistograms()
+        {
+            var histogramValue = new BucketHistogramValue(1, 1, new Dictionary<long, long> { { 1, 1 } });
+            var histogram = new BucketHistogramValueSource(BucketHistogramNameDefault, ConstantValue.Provider(histogramValue), Unit.Items, Tags);
+
+            return new[] { histogram };
+        }
+
 
 #pragma warning disable SA1118 // Parameter must not span multiple lines
 

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
@@ -151,7 +151,7 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         private IEnumerable<BucketHistogramValueSource> SetupBucketHistograms()
         {
-            var histogramValue = new BucketHistogramValue(1, 1, new Dictionary<long, long> { { 1, 1 } });
+            var histogramValue = new BucketHistogramValue(1, 1, new Dictionary<double, long> { { 1, 1 } });
             var histogram = new BucketHistogramValueSource(BucketHistogramNameDefault, ConstantValue.Provider(histogramValue), Unit.Items, Tags);
 
             return new[] { histogram };

--- a/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
+++ b/src/Core/test/App.Metrics.Formatters.Json.Facts/TestFixtures/MetricProviderTestFixture.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.FactsCommon;
 using App.Metrics.Gauge;
@@ -28,19 +29,21 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
             Meters = SetupMeters();
             Gauges = SetupGauges();
             Timers = SetupTimers();
+            BucketTimers = SetupBucketTimers();
             ApdexScores = SetupApdexScores();
             Histograms = SetupHistograms();
             BucketHistograms = SetupBucketHistograms();
             ContextOne = SetupContextOne();
             DataWithOneContext = SetupMetricsData(new[] { ContextOne });
-            ApdexContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), ApdexScores) });
-            CounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Counters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            ResetCounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), ResetCounters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            GaugeContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Gauges, Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            MeterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Meters, Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            TimerContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Timers, Enumerable.Empty<ApdexValueSource>()) });
-            HistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Histograms, Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
-            BucketHistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), BucketHistograms, Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            ApdexContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), ApdexScores) });
+            CounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Counters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            ResetCounterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), ResetCounters, Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            GaugeContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Gauges, Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            MeterContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Meters, Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            TimerContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Timers, Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            BucketTimerContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), BucketTimers, Enumerable.Empty<ApdexValueSource>()) });
+            HistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Histograms, Enumerable.Empty<BucketHistogramValueSource>(), Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
+            BucketHistogramContext = SetupMetricsData(new[] { new MetricsContextValueSource("context_one", Enumerable.Empty<GaugeValueSource>(), Enumerable.Empty<CounterValueSource>(), Enumerable.Empty<MeterValueSource>(), Enumerable.Empty<HistogramValueSource>(), BucketHistograms, Enumerable.Empty<TimerValueSource>(), Enumerable.Empty<BucketTimerValueSource>(), Enumerable.Empty<ApdexValueSource>()) });
         }
 
         public string ApdexNameDefault { get; } = "test_apdex";
@@ -64,6 +67,8 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
         public MetricsDataValueSource MeterContext { get; }
 
         public MetricsDataValueSource TimerContext { get; }
+
+        public MetricsDataValueSource BucketTimerContext { get; }
 
         public MetricsDataValueSource HistogramContext { get; }
 
@@ -104,6 +109,10 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         public IEnumerable<TimerValueSource> Timers { get; }
 
+        public string BucketTimerNameDefault { get; } = "test_bucket_timer";
+
+        public IEnumerable<BucketTimerValueSource> BucketTimers { get; }
+
         private MetricsContextValueSource ContextOne { get; }
 
         private MetricTags Tags => new MetricTags(new[] { "host", "env" }, new[] { "server1", "staging" });
@@ -120,7 +129,7 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         private MetricsContextValueSource SetupContextOne()
         {
-            return new MetricsContextValueSource("context_one", Gauges, Counters, Meters, Histograms, BucketHistograms, Timers, ApdexScores);
+            return new MetricsContextValueSource("context_one", Gauges, Counters, Meters, Histograms, BucketHistograms, Timers, BucketTimers, ApdexScores);
         }
 
         private IEnumerable<CounterValueSource> SetupCounters(bool resetOnReporting)
@@ -151,7 +160,7 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
 
         private IEnumerable<BucketHistogramValueSource> SetupBucketHistograms()
         {
-            var histogramValue = new BucketHistogramValue(1, 1, new Dictionary<double, long> { { 1, 1 } });
+            var histogramValue = new BucketHistogramValue(1, 1, new Dictionary<double, double> { { 1, 1 } });
             var histogram = new BucketHistogramValueSource(BucketHistogramNameDefault, ConstantValue.Provider(histogramValue), Unit.Items, Tags);
 
             return new[] { histogram };
@@ -215,6 +224,35 @@ namespace App.Metrics.Formatters.Json.Facts.TestFixtures
             var timerValue = new TimerValue(meterValue, histogramValue, 0, TimeUnit.Nanoseconds);
             var timer = new TimerValueSource(
                 TimerNameDefault,
+                ConstantValue.Provider(timerValue),
+                Unit.Requests,
+                TimeUnit.Seconds,
+                TimeUnit.Milliseconds,
+                Tags);
+
+            return new[] { timer };
+        }
+
+        private IEnumerable<BucketTimerValueSource> SetupBucketTimers()
+        {
+            const int count = 5;
+
+            var meterValue = new MeterValue(
+                count,
+                1,
+                2,
+                3,
+                4,
+                TimeUnit.Seconds,
+                new[]
+                {
+                    new MeterValue.SetItem("item", 0.5, new MeterValue(1, 2, 3, 4, 5, TimeUnit.Seconds, new MeterValue.SetItem[0]))
+                });
+            var histogramValue = new BucketHistogramValue(count, 1, new Dictionary<double, double> { { 1, 1 } });
+
+            var timerValue = new BucketTimerValue(meterValue, histogramValue, 0, TimeUnit.Nanoseconds);
+            var timer = new BucketTimerValueSource(
+                BucketTimerNameDefault,
                 ConstantValue.Provider(timerValue),
                 Unit.Requests,
                 TimeUnit.Seconds,

--- a/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandbox/GrafanaCloudHostedMetricsSandbox.csproj
+++ b/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandbox/GrafanaCloudHostedMetricsSandbox.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics" />
+    <PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />

--- a/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandboxMvc/GrafanaCloudHostedMetricsSandboxMvc.csproj
+++ b/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandboxMvc/GrafanaCloudHostedMetricsSandboxMvc.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.AspNetCore.Health" />
-    <PackageReference Include="App.Metrics.AspNetCore.Mvc" />
-    <PackageReference Include="App.Metrics.Health.Reporting.Metrics" />
+    <PackageReference Include="App.Metrics.AspNetCore.Health" Version="3.2.0-bucket-histograms0029" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.2.0-bucket-histograms0029" />
+    <PackageReference Include="App.Metrics.Health.Reporting.Metrics" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Reporting/sandbox/MetricsGraphiteSandbox/MetricsGraphiteSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsGraphiteSandbox/MetricsGraphiteSandbox.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="App.Metrics" />
+	  <PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
 	  <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
 	  <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />

--- a/src/Reporting/sandbox/MetricsGraphiteSandboxMvc/MetricsGraphiteSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsGraphiteSandboxMvc/MetricsGraphiteSandboxMvc.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>        
-    <PackageReference Include="App.Metrics.AspNetCore.Mvc" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.2.0-bucket-histograms0029" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Reporting/sandbox/MetricsInfluxDBSandbox/MetricsInfluxDBSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsInfluxDBSandbox/MetricsInfluxDBSandbox.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="App.Metrics" />
+		<PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
 		<PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
 		<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />

--- a/src/Reporting/sandbox/MetricsInfluxDBSandboxMvc/MetricsInfluxDBSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsInfluxDBSandboxMvc/MetricsInfluxDBSandboxMvc.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.AspNetCore.Health" />
-    <PackageReference Include="App.Metrics.AspNetCore.Mvc" />
-    <PackageReference Include="App.Metrics.Health.Reporting.Metrics" />
+    <PackageReference Include="App.Metrics.AspNetCore.Health" Version="3.2.0-bucket-histograms0029" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.2.0-bucket-histograms0029" />
+    <PackageReference Include="App.Metrics.Health.Reporting.Metrics" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Reporting/sandbox/MetricsPrometheusSandbox/ApplicationsMetricsRegistry.cs
+++ b/src/Reporting/sandbox/MetricsPrometheusSandbox/ApplicationsMetricsRegistry.cs
@@ -8,6 +8,7 @@ using App.Metrics.Gauge;
 using App.Metrics.Histogram;
 using App.Metrics.Meter;
 using App.Metrics.Timer;
+using App.Metrics.BucketTimer;
 
 namespace MetricsPrometheusSandbox
 {
@@ -42,5 +43,10 @@ namespace MetricsPrometheusSandbox
                                                {
                                                    Name = "timer_one"
                                                };
+
+        public static BucketTimerOptions BucketTimerOne => new BucketTimerOptions
+        {
+            Name = "bucket_timer_one"
+        };
     }
 }

--- a/src/Reporting/sandbox/MetricsPrometheusSandbox/Host.cs
+++ b/src/Reporting/sandbox/MetricsPrometheusSandbox/Host.cs
@@ -85,6 +85,11 @@ namespace MetricsPrometheusSandbox
                 Thread.Sleep(Rnd.Next(0, 100));
             }
 
+            using (Metrics.Measure.BucketTimer.Time(ApplicationsMetricsRegistry.BucketTimerOne))
+            {
+                Thread.Sleep(Rnd.Next(0, 100));
+            }
+
             using (Metrics.Measure.Apdex.Track(ApplicationsMetricsRegistry.ApdexOne))
             {
                 Thread.Sleep(Rnd.Next(0, 100));

--- a/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
@@ -16,11 +16,13 @@
 	</PropertyGroup>
 	
 		<ItemGroup>
-		<Content Include="appsettings.json" />
+		<Content Include="appsettings.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="App.Metrics" />
+		<PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
 		<PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
 		<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />

--- a/src/Reporting/sandbox/MetricsPrometheusSandboxMvc/MetricsPrometheusSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsPrometheusSandboxMvc/MetricsPrometheusSandboxMvc.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.AspNetCore.Mvc" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.2.0-bucket-histograms0029" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Serilog.AspNetCore " Version="2.1.2-*" />
   </ItemGroup>

--- a/src/Reporting/sandbox/MetricsReceiveSanboxApi/MetricsReceiveSanboxApi.csproj
+++ b/src/Reporting/sandbox/MetricsReceiveSanboxApi/MetricsReceiveSanboxApi.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics" />
+    <PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />

--- a/src/Reporting/sandbox/ReportingSandbox/ReportingSandbox.csproj
+++ b/src/Reporting/sandbox/ReportingSandbox/ReportingSandbox.csproj
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics" />
-    <PackageReference Include="App.Metrics.Extensions.DependencyInjection" />
-    <PackageReference Include="App.Metrics.Extensions.Hosting" />
+    <PackageReference Include="App.Metrics" Version="3.2.0-bucket-histograms0028" />
+    <PackageReference Include="App.Metrics.Extensions.DependencyInjection" Version="3.2.0-bucket-histograms0029" />
+    <PackageReference Include="App.Metrics.Extensions.Hosting" Version="3.2.0-bucket-histograms0029" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />

--- a/src/Reporting/src/App.Metrics.Formatters.GrafanaCloudHostedMetrics/App.Metrics.Formatters.GrafanaCloudHostedMetrics.csproj
+++ b/src/Reporting/src/App.Metrics.Formatters.GrafanaCloudHostedMetrics/App.Metrics.Formatters.GrafanaCloudHostedMetrics.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Reporting/src/App.Metrics.Formatters.Graphite/App.Metrics.Formatters.Graphite.csproj
+++ b/src/Reporting/src/App.Metrics.Formatters.Graphite/App.Metrics.Formatters.Graphite.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Formatters.InfluxDB/App.Metrics.Formatters.InfluxDB.csproj
+++ b/src/Reporting/src/App.Metrics.Formatters.InfluxDB/App.Metrics.Formatters.InfluxDB.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/App.Metrics.Formatters.Prometheus.csproj
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/App.Metrics.Formatters.Prometheus.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
   </ItemGroup>
 

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
@@ -100,6 +100,23 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     result.Add(promMetricFamily);
                 }
 
+                foreach (var metricGroup in group.BucketHistograms.GroupBy(
+                    source => source.IsMultidimensional ? source.MultidimensionalName : source.Name))
+                {
+                    var promMetricFamily = new MetricFamily
+                    {
+                        name = metricNameFormatter(group.Context, metricGroup.Key),
+                        type = MetricType.SUMMARY
+                    };
+
+                    foreach (var timer in metricGroup)
+                    {
+                        promMetricFamily.metric.AddRange(timer.ToPrometheusMetrics());
+                    }
+
+                    result.Add(promMetricFamily);
+                }
+
                 foreach (var metricGroup in group.Timers.GroupBy(
                     source => source.IsMultidimensional ? source.MultidimensionalName : source.Name))
                 {

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
@@ -133,6 +133,23 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
 
                     result.Add(promMetricFamily);
                 }
+
+                foreach (var metricGroup in group.BucketTimers.GroupBy(
+                    source => source.IsMultidimensional ? source.MultidimensionalName : source.Name))
+                {
+                    var promMetricFamily = new MetricFamily
+                    {
+                        name = metricNameFormatter(group.Context, metricGroup.Key),
+                        type = MetricType.SUMMARY
+                    };
+
+                    foreach (var timer in metricGroup)
+                    {
+                        promMetricFamily.metric.AddRange(timer.ToPrometheusMetrics());
+                    }
+
+                    result.Add(promMetricFamily);
+                }
             }
 
             return result;

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -116,6 +117,35 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                                  label = metric.Tags.ToLabelPairs()
                              }
                          };
+
+            return result;
+        }
+
+        public static IEnumerable<Metric> ToPrometheusMetrics(this BucketHistogramValueSource metric)
+        {
+            var histogram = new Histogram
+            {
+                sample_count = (ulong) metric.Value.Count,
+                sample_sum = metric.Value.Sum
+            };
+
+            foreach (var keyValuePair in metric.Value.Buckets)
+            {
+                histogram.bucket.Add(new Bucket
+                {
+                    cumulative_count = (ulong)keyValuePair.Value,
+                    upper_bound = keyValuePair.Key
+                });
+            }
+
+            var result = new List<Metric>
+            {
+                new Metric
+                {
+                    histogram = histogram,
+                    label = metric.Tags.ToLabelPairs()
+                }
+            };
 
             return result;
         }

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Gauge;
 using App.Metrics.Histogram;
@@ -130,6 +131,35 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
             };
 
             foreach (var keyValuePair in metric.Value.Buckets)
+            {
+                histogram.bucket.Add(new Bucket
+                {
+                    cumulative_count = (ulong)keyValuePair.Value,
+                    upper_bound = keyValuePair.Key
+                });
+            }
+
+            var result = new List<Metric>
+            {
+                new Metric
+                {
+                    histogram = histogram,
+                    label = metric.Tags.ToLabelPairs()
+                }
+            };
+
+            return result;
+        }
+
+        public static IEnumerable<Metric> ToPrometheusMetrics(this BucketTimerValueSource metric)
+        {
+            var histogram = new Histogram
+            {
+                sample_count = (ulong)metric.Value.Histogram.Count,
+                sample_sum = metric.Value.Histogram.Sum
+            };
+
+            foreach (var keyValuePair in metric.Value.Histogram.Buckets)
             {
                 histogram.bucket.Add(new Bucket
                 {

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricValueSourceExtensions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) App Metrics Contributors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using App.Metrics.Apdex;
@@ -163,7 +164,7 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
             {
                 histogram.bucket.Add(new Bucket
                 {
-                    cumulative_count = (ulong)keyValuePair.Value,
+                    cumulative_count = Convert.ToUInt64(keyValuePair.Value),
                     upper_bound = keyValuePair.Key
                 });
             }

--- a/src/Reporting/src/App.Metrics.Reporting.Console/App.Metrics.Reporting.Console.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.Console/App.Metrics.Reporting.Console.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
-    <PackageReference Include="App.Metrics.Formatters.Ascii" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
+    <PackageReference Include="App.Metrics.Formatters.Ascii" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.GrafanaCloudHostedMetrics/App.Metrics.Reporting.GrafanaCloudHostedMetrics.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.GrafanaCloudHostedMetrics/App.Metrics.Reporting.GrafanaCloudHostedMetrics.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Abstractions"/>
+    <PackageReference Include="App.Metrics.Abstractions" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Reporting/src/App.Metrics.Reporting.Graphite/App.Metrics.Reporting.Graphite.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.Graphite/App.Metrics.Reporting.Graphite.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="App.Metrics.Abstractions" />
+		<PackageReference Include="App.Metrics.Abstractions" Version="3.2.0-bucket-histograms0028" />
 	</ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.Http/App.Metrics.Reporting.Http.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.Http/App.Metrics.Reporting.Http.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
-    <PackageReference Include="App.Metrics.Formatters.Json" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
+    <PackageReference Include="App.Metrics.Formatters.Json" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.InfluxDB/App.Metrics.Reporting.InfluxDB.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.InfluxDB/App.Metrics.Reporting.InfluxDB.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="App.Metrics.Abstractions" />
+		<PackageReference Include="App.Metrics.Abstractions" Version="3.2.0-bucket-histograms0028" />
 	</ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/App.Metrics.Reporting.Socket.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/App.Metrics.Reporting.Socket.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.TextFile/App.Metrics.Reporting.TextFile.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.TextFile/App.Metrics.Reporting.TextFile.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" />
-    <PackageReference Include="App.Metrics.Formatters.Ascii" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
+    <PackageReference Include="App.Metrics.Formatters.Ascii" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/test/App.Metrics.Reporting.FactsCommon/App.Metrics.Reporting.FactsCommon.csproj
+++ b/src/Reporting/test/App.Metrics.Reporting.FactsCommon/App.Metrics.Reporting.FactsCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Core" Version="$(AppMetricsCoreVersion)" />
+    <PackageReference Include="App.Metrics.Core" Version="3.2.0-bucket-histograms0028" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/test/App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts/MetricSnapshotHostedMetricsJsonWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts/MetricSnapshotHostedMetricsJsonWriterTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.GrafanaCloudHostedMetrics;
 using App.Metrics.Gauge;
@@ -485,6 +486,7 @@ namespace App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts
             HistogramValueSource histograms = null,
             BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
+            BucketTimerValueSource bucketTimers = null,
             ApdexValueSource apdexScores = null)
         {
             var gaugeValues = gauges != null ? new[] { gauges } : Enumerable.Empty<GaugeValueSource>();
@@ -493,9 +495,10 @@ namespace App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
             var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
+            var bucketTimerValues = bucketTimers != null ? new[] { bucketTimers } : Enumerable.Empty<BucketTimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, bucketTimerValues, apdexScoreValues);
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts/MetricSnapshotHostedMetricsJsonWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts/MetricSnapshotHostedMetricsJsonWriterTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.GrafanaCloudHostedMetrics;
 using App.Metrics.Gauge;
@@ -482,6 +483,7 @@ namespace App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts
             CounterValueSource counters = null,
             MeterValueSource meters = null,
             HistogramValueSource histograms = null,
+            BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
             ApdexValueSource apdexScores = null)
         {
@@ -489,10 +491,11 @@ namespace App.Metrics.Reporting.GrafanaCloudHostedMetrics.Facts
             var counterValues = counters != null ? new[] { counters } : Enumerable.Empty<CounterValueSource>();
             var meterValues = meters != null ? new[] { meters } : Enumerable.Empty<MeterValueSource>();
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
+            var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.Graphite.Facts/MetricSnapshotPlainTextProtocolWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.Graphite.Facts/MetricSnapshotPlainTextProtocolWriterTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.Graphite;
 using App.Metrics.Gauge;
@@ -485,6 +486,7 @@ namespace App.Metrics.Reporting.Graphite.Facts
             HistogramValueSource histograms = null,
             BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
+            BucketTimerValueSource bucketTimers = null,
             ApdexValueSource apdexScores = null)
         {
             var gaugeValues = gauges != null ? new[] { gauges } : Enumerable.Empty<GaugeValueSource>();
@@ -493,9 +495,10 @@ namespace App.Metrics.Reporting.Graphite.Facts
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
             var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
+            var bucketTimerValues = bucketTimers != null ? new[] { bucketTimers } : Enumerable.Empty<BucketTimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, bucketTimerValues, apdexScoreValues);
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.Graphite.Facts/MetricSnapshotPlainTextProtocolWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.Graphite.Facts/MetricSnapshotPlainTextProtocolWriterTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.Graphite;
 using App.Metrics.Gauge;
@@ -482,6 +483,7 @@ namespace App.Metrics.Reporting.Graphite.Facts
             CounterValueSource counters = null,
             MeterValueSource meters = null,
             HistogramValueSource histograms = null,
+            BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
             ApdexValueSource apdexScores = null)
         {
@@ -489,10 +491,11 @@ namespace App.Metrics.Reporting.Graphite.Facts
             var counterValues = counters != null ? new[] { counters } : Enumerable.Empty<CounterValueSource>();
             var meterValues = meters != null ? new[] { meters } : Enumerable.Empty<MeterValueSource>();
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
+            var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/MetricSnapshotInfluxDBLineProtocolWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/MetricSnapshotInfluxDBLineProtocolWriterTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
 using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.InfluxDB;
 using App.Metrics.Gauge;
@@ -484,6 +485,7 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
             HistogramValueSource histograms = null,
             BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
+            BucketTimerValueSource bucketTimers = null,
             ApdexValueSource apdexScores = null)
         {
             var gaugeValues = gauges != null ? new[] { gauges } : Enumerable.Empty<GaugeValueSource>();
@@ -492,9 +494,10 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
             var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
+            var bucketTimerValues = bucketTimers != null ? new[] { bucketTimers } : Enumerable.Empty<BucketTimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, bucketTimerValues, apdexScoreValues);
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/MetricSnapshotInfluxDBLineProtocolWriterTests.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.InfluxDB.Facts/MetricSnapshotInfluxDBLineProtocolWriterTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
 using App.Metrics.Counter;
 using App.Metrics.Formatters.InfluxDB;
 using App.Metrics.Gauge;
@@ -481,6 +482,7 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
             CounterValueSource counters = null,
             MeterValueSource meters = null,
             HistogramValueSource histograms = null,
+            BucketHistogramValueSource bucketHistograms = null,
             TimerValueSource timers = null,
             ApdexValueSource apdexScores = null)
         {
@@ -488,10 +490,11 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
             var counterValues = counters != null ? new[] { counters } : Enumerable.Empty<CounterValueSource>();
             var meterValues = meters != null ? new[] { meters } : Enumerable.Empty<MeterValueSource>();
             var histogramValues = histograms != null ? new[] { histograms } : Enumerable.Empty<HistogramValueSource>();
+            var bucketHistogramValues = bucketHistograms != null ? new[] { bucketHistograms } : Enumerable.Empty<BucketHistogramValueSource>();
             var timerValues = timers != null ? new[] { timers } : Enumerable.Empty<TimerValueSource>();
             var apdexScoreValues = apdexScores != null ? new[] { apdexScores } : Enumerable.Empty<ApdexValueSource>();
 
-            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, timerValues, apdexScoreValues);
+            return new MetricsContextValueSource(context, gaugeValues, counterValues, meterValues, histogramValues, bucketHistogramValues, timerValues, apdexScoreValues);
         }
     }
 }


### PR DESCRIPTION
### The issue or feature being addressed

This is a start on the new metric required for AppMetrics/AppMetrics#278 (New metric type for Prometheus histograms)

### Details on the issue fix or feature implementation

I have created a new BucketHistogram which allows the end user to decide which buckets they would like and then keeps a count for each bucket.

The bucket to increment is based on finding the largest bucket that is <= to the value

I'd like to get people thoughts on this before going too far

### Confirm the following

- [X ] I have ensured that I have merged the latest changes from the dev branch
- [X ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ X] I have included unit tests for the issue/feature
- [X ] I have included the github issue number in my commits
