### PR TITLE
Use await using for .NET Standard 2.1

### DIFF
--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/App.Metrics.Formatters.Prometheus.csproj
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/App.Metrics.Formatters.Prometheus.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>App Metrics Formatting, formatting metrics data to Prometheus formats.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <PackageTags>appmetrics;prometheus</PackageTags>    
   </PropertyGroup>
 

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
@@ -29,7 +29,11 @@ namespace App.Metrics.Formatters.Prometheus.Internal
         public static async Task Write(Stream destination, IEnumerable<MetricFamily> metrics, NewLineFormat newLine)
         {
             var metricFamilies = metrics.ToArray();
+#if NETSTANDARD2_1
+            await using (var streamWriter = new StreamWriter(destination, Encoding, bufferSize: 1024, leaveOpen: true) { NewLine = GetNewLineChar(newLine) })
+#else
             using (var streamWriter = new StreamWriter(destination, Encoding, bufferSize: 1024, leaveOpen: true) { NewLine = GetNewLineChar(newLine) })
+#endif
             {
                 foreach (var metricFamily in metricFamilies)
                 {


### PR DESCRIPTION

### The issue or feature being addressed

https://github.com/AppMetrics/AppMetrics/issues/396

```
System.InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream.Flush()
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.Dispose(Boolean disposing)
   at System.IO.TextWriter.Dispose()
   at App.Metrics.Formatters.Prometheus.Internal.AsciiFormatter.Write(Stream destination, IEnumerable`1 metrics, NewLineFormat newLine)
   at App.Metrics.Formatters.Prometheus.MetricsPrometheusTextOutputFormatter.WriteAsync(Stream output, MetricsDataValueSource metricsData, CancellationToken cancellationToken)
```

### Details on the issue fix or feature implementation

Should call `IAsyncDisposable.DisposeAsync` when ASP.NET Core 3 is used.
Don't know if targeting .NET Standard 2.1 is the recommended solution to this kind of thing but at least it should be `await using` if available.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
