### PR TITLE
AsciiFormatter use async all the way down (#520)

### DIFF
--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/AsciiFormatter.cs
@@ -37,54 +37,54 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             {
                 foreach (var metricFamily in metricFamilies)
                 {
-                    WriteFamily(streamWriter, metricFamily);
+                    await WriteFamily(streamWriter, metricFamily);
                 }
 
                 await streamWriter.FlushAsync();
             }
         }
 
-        private static void WriteFamily(StreamWriter streamWriter, MetricFamily metricFamily)
+        private static async Task WriteFamily(StreamWriter streamWriter, MetricFamily metricFamily)
         {
-            streamWriter.Write("# HELP ");
-            streamWriter.Write(metricFamily.name);
-            streamWriter.Write(' ');
-            streamWriter.WriteLine(metricFamily.help);
+            await streamWriter.WriteAsync("# HELP ");
+            await streamWriter.WriteAsync(metricFamily.name);
+            await streamWriter.WriteAsync(' ');
+            await streamWriter.WriteLineAsync(metricFamily.help);
 
-            streamWriter.Write("# TYPE ");
-            streamWriter.Write(metricFamily.name);
-            streamWriter.Write(' ');
-            streamWriter.WriteLine(ToString(metricFamily.type));
+            await streamWriter.WriteAsync("# TYPE ");
+            await streamWriter.WriteAsync(metricFamily.name);
+            await streamWriter.WriteAsync(' ');
+            await streamWriter.WriteLineAsync(ToString(metricFamily.type));
 
             foreach (var metric in metricFamily.metric)
             {
-                WriteMetric(streamWriter, metricFamily, metric);
-                streamWriter.WriteLine();
+                await WriteMetric(streamWriter, metricFamily, metric);
+                await streamWriter.WriteLineAsync();
             }
         }
 
-        private static void WriteMetric(StreamWriter streamWriter, MetricFamily family, Metric metric)
+        private static async Task WriteMetric(StreamWriter streamWriter, MetricFamily family, Metric metric)
         {
             var familyName = family.name;
 
             if (metric.gauge != null)
             {
-                WriteSimpleValue(streamWriter, familyName, metric.gauge.value, metric.label);
+                await WriteSimpleValue(streamWriter, familyName, metric.gauge.value, metric.label);
             }
             else if (metric.counter != null)
             {
-                WriteSimpleValue(streamWriter, familyName, metric.counter.value, metric.label);
+                await WriteSimpleValue(streamWriter, familyName, metric.counter.value, metric.label);
             }
             else if (metric.summary != null)
             {
-                WriteSimpleValue(streamWriter, familyName, metric.summary.sample_sum, metric.label, "_sum");
-                WriteSimpleValue(streamWriter, familyName, metric.summary.sample_count, metric.label, "_count");
+                await WriteSimpleValue(streamWriter, familyName, metric.summary.sample_sum, metric.label, "_sum");
+                await WriteSimpleValue(streamWriter, familyName, metric.summary.sample_count, metric.label, "_count");
 
                 foreach (var quantileValuePair in metric.summary.quantile)
                 {
                     var quantile = double.IsPositiveInfinity(quantileValuePair.quantile) ? "+Inf" : quantileValuePair.quantile.ToString(CultureInfo.InvariantCulture);
 
-                    WriteSimpleValue(
+                    await WriteSimpleValue(
                         streamWriter,
                         familyName,
                         quantileValuePair.value,
@@ -93,13 +93,13 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
             else if (metric.histogram != null)
             {
-                WriteSimpleValue(streamWriter, familyName, metric.histogram.sample_sum, metric.label, "_sum");
-                WriteSimpleValue(streamWriter, familyName, metric.histogram.sample_count, metric.label, "_count");
+                await WriteSimpleValue(streamWriter, familyName, metric.histogram.sample_sum, metric.label, "_sum");
+                await WriteSimpleValue(streamWriter, familyName, metric.histogram.sample_count, metric.label, "_count");
                 foreach (var bucket in metric.histogram.bucket)
                 {
                     var value = double.IsPositiveInfinity(bucket.upper_bound) ? "+Inf" : bucket.upper_bound.ToString(CultureInfo.InvariantCulture);
 
-                    WriteSimpleValue(
+                    await WriteSimpleValue(
                         streamWriter,
                         familyName,
                         bucket.cumulative_count,
@@ -113,34 +113,34 @@ namespace App.Metrics.Formatters.Prometheus.Internal
             }
         }
 
-        private static void WriteSimpleValue(StreamWriter writer, string family, double value, IEnumerable<LabelPair> labels, string namePostfix = null)
+        private static async Task WriteSimpleValue(StreamWriter writer, string family, double value, IEnumerable<LabelPair> labels, string namePostfix = null)
         {
-            writer.Write(family);
+            await writer.WriteAsync(family);
             if (namePostfix != null)
             {
-                writer.Write(namePostfix);
+                await writer.WriteAsync(namePostfix);
             }
 
             bool any = false;
             foreach (var l in labels)
             {
-                writer.Write(any ? ',' : '{');
+                await writer.WriteAsync(any ? ',' : '{');
 
-                writer.Write(l.name);
-                writer.Write("=\"");
-                writer.Write(l.value);
-                writer.Write('"');
+                await writer.WriteAsync(l.name);
+                await writer.WriteAsync("=\"");
+                await writer.WriteAsync(l.value);
+                await writer.WriteAsync('"');
 
                 any = true;
             }
 
             if (any)
             {
-                writer.Write('}');
+                await writer.WriteAsync('}');
             }
 
-            writer.Write(' ');
-            writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+            await writer.WriteAsync(' ');
+            await writer.WriteLineAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         private static string GetNewLineChar(NewLineFormat newLine)


### PR DESCRIPTION
### The issue or feature being addressed

- #520

### Details on the issue fix or feature implementation

.NET Core 3.0 block sync operations by default. I've changed the implementation of App.Metrics.Formatters.Prometheus.Internal.AsciiFormatter to use async all the way down. 

### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
  ` I've branched from features/4.0.0 where the fix was already started`
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits
