### PR TITLE
Switch to .NET Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To run, from the solution's root:
 
 ```
 	cd .\benchmarks\App.Metrics.Benchmarks.Runner\
-	dotnet run -c "Release" --framework netcoreapp3.0
+	dotnet run -c "Release" --framework netcoreapp3.1
 ```
 
 You'll then be prompted to choose a benchmark to run which will output a markdown file with the result in directory `.\benchmarks\App.Metrics.Benchmarks.Runner\BenchmarkDotNet.Artifacts\results`.

--- a/clear_bin_and_obj.ps1
+++ b/clear_bin_and_obj.ps1
@@ -1,0 +1,2 @@
+Get-ChildItem .\ -Include bin,obj -Recurse | Where { $_.fullname -notlike "*node_modules*" } | foreach ($_) { remove-item $_.fullname -Force -Recurse }
+dotnet build-server shutdown

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test", "benchmarks", "sandbox" ],
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.1.200"
   }
 }

--- a/src/AspNetCore/AspNetCore.sln
+++ b/src/AspNetCore/AspNetCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29920.165
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2D805782-756E-4C98-B22E-F502BEE95318}"
 	ProjectSection(SolutionItems) = preProject
@@ -54,6 +54,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.AspNetCore.Mvc.Core", "src\App.Metrics.AspNetCore.Mvc.Core\App.Metrics.AspNetCore.Mvc.Core.csproj", "{8FC832BB-1EDB-43E6-9844-05CB949ADCA7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.AspNetCore.Tracking.Facts", "test\App.Metrics.AspNetCore.Tracking.Facts\App.Metrics.AspNetCore.Tracking.Facts.csproj", "{32DD796A-48CD-4622-B0A1-B889A4661D88}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsSandboxCore31", "sandbox\MetricsSandboxCore31\MetricsSandboxCore31.csproj", "{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -121,6 +123,10 @@ Global
 		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32DD796A-48CD-4622-B0A1-B889A4661D88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,6 +148,7 @@ Global
 		{6B54766A-C439-47AB-B44A-887396E203E5} = {C0BC96C5-46E1-4323-9C5D-58D9A96549CD}
 		{8FC832BB-1EDB-43E6-9844-05CB949ADCA7} = {2D805782-756E-4C98-B22E-F502BEE95318}
 		{32DD796A-48CD-4622-B0A1-B889A4661D88} = {DD2E4647-7125-4CE3-9BA5-B45A26113A31}
+		{47750B83-A5ED-4FE5-AFFF-C901E8E7ED5C} = {C0BC96C5-46E1-4323-9C5D-58D9A96549CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8699A1D-0BA1-403C-86E9-C789CD2645EB}

--- a/src/AspNetCore/build/build.csproj
+++ b/src/AspNetCore/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetCore/sandbox/Directory.Build.props
+++ b/src/AspNetCore/sandbox/Directory.Build.props
@@ -7,15 +7,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044*" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />
-    <PackageReference Include="Serilog.AspNetCore " Version="3.1.0" />
+    <PackageReference Include="Serilog.AspNetCore " Version="3.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore/sandbox/MetricsReportingSandboxMvc/MetricsReportingSandboxMvc.csproj
+++ b/src/AspNetCore/sandbox/MetricsReportingSandboxMvc/MetricsReportingSandboxMvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/Controllers/WeatherForecastController.cs
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/Controllers/WeatherForecastController.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace MetricsSandboxCore31.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/MetricsSandboxCore31.csproj
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/MetricsSandboxCore31.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\App.Metrics.AspNetCore\App.Metrics.AspNetCore.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/Program.cs
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/Program.cs
@@ -1,0 +1,31 @@
+using App.Metrics;
+using App.Metrics.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace MetricsSandboxCore31
+{
+    public static class Program
+    {
+        public static IMetricsRoot Metrics { get; set; }
+
+        public static void Main(string[] args)
+        {
+            Metrics = AppMetrics.CreateDefaultBuilder()
+                .OutputMetrics.AsJson()
+                .OutputMetrics.AsPlainText()
+                .Build();
+
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureMetrics(Metrics)
+                .UseMetrics()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/Properties/launchSettings.json
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53855",
+      "sslPort": 44314
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "MetricsSandboxCore31": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/Startup.cs
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/Startup.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MetricsSandboxCore31
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/WeatherForecast.cs
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace MetricsSandboxCore31
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/appsettings.Development.json
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxCore31/appsettings.json
+++ b/src/AspNetCore/sandbox/MetricsSandboxCore31/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/AspNetCore/sandbox/MetricsSandboxMvc/MetricsSandboxMvc.csproj
+++ b/src/AspNetCore/sandbox/MetricsSandboxMvc/MetricsSandboxMvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="Package References">

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Abstractions/App.Metrics.AspNetCore.Abstractions.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Abstractions/App.Metrics.AspNetCore.Abstractions.csproj
@@ -2,15 +2,22 @@
 
 	<PropertyGroup>
 		<Description>App Metrics ASP.NET Core abstractions and interfaces for routing, HTTP response formatting and more.</Description>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
 		<PackageTags>appmetrics;aspnetcore;metrics</PackageTags>	  
 		<RootNamespace>App.Metrics.AspNetCore</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="App.Metrics.Abstractions" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
 		<PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
 	</ItemGroup>
-
+	
 </Project>

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/App.Metrics.AspNetCore.Core.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/App.Metrics.AspNetCore.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core core components.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>App.Metrics.AspNetCore</RootNamespace>
     <PackageTags>appmetrics;aspnetcore;metrics</PackageTags>
   </PropertyGroup>
@@ -11,11 +11,18 @@
     <PackageReference Include="App.Metrics.Core" />
     <PackageReference Include="App.Metrics.Extensions.Configuration" />
     <PackageReference Include="App.Metrics.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" />
+	</ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\App.Metrics.AspNetCore.Abstractions\App.Metrics.AspNetCore.Abstractions.csproj" />
   </ItemGroup>

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/App.Metrics.AspNetCore.Endpoints.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/App.Metrics.AspNetCore.Endpoints.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core Endpoints provides the ability to expose metrics and environment information as web endpoints.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;metrics</PackageTags>
   </PropertyGroup>
   

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Hosting/App.Metrics.AspNetCore.Hosting.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Hosting/App.Metrics.AspNetCore.Hosting.csproj
@@ -2,13 +2,17 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core Hosting provides extensions to configure App Metrics in an ASP.NET Core application.</Description>	
-    <TargetFramework>netstandard2.0</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>    
     <PackageTags>appmetrics;aspnetcore;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
-  </ItemGroup>
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\App.Metrics.AspNetCore.Core\App.Metrics.AspNetCore.Core.csproj" />

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Reporting/App.Metrics.AspNetCore.Reporting.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Reporting/App.Metrics.AspNetCore.Reporting.csproj
@@ -2,12 +2,16 @@
 
 	<PropertyGroup>    
 		<Description>[Obsolete - App Metrics ASP.NET Core Reporting provides the abliity to report metrics in web application] HostedService for metric reporting moved to App.Metrics.Extensions.Hosting now that HostedService is supported outside of a web context in net core 2.1.0</Description>	
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
 		<PackageTags>appmetrics;aspnetcore;metrics;reporting</PackageTags>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+  	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    	<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Routing/App.Metrics.AspNetCore.Routing.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Routing/App.Metrics.AspNetCore.Routing.csproj
@@ -2,13 +2,17 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core Routing features such as exposing route templates to App Metrics for tagging request based metrics.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;aspnetcoremvc;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Routing" />
-  </ItemGroup>
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\App.Metrics.AspNetCore.Abstractions\App.Metrics.AspNetCore.Abstractions.csproj" />

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/App.Metrics.AspNetCore.Tracking.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/App.Metrics.AspNetCore.Tracking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>    
     <Description>App Metrics ASP.NET Core Tracking provides the ability to automatically collect typical web metrics from an ASP.NET Core application.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;metrics</PackageTags>
   </PropertyGroup>
   

--- a/src/AspNetCore/src/App.Metrics.AspNetCore/App.Metrics.AspNetCore.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore/App.Metrics.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core is a an open-source web framework allowing you to record typical web metrics and expose metrics and environment information over HTTP and more.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;metrics</PackageTags>
   </PropertyGroup>
 

--- a/src/AspNetCore/test/Directory.Build.props
+++ b/src/AspNetCore/test/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
    <ItemGroup>

--- a/src/Core/benchmarks/App.Metrics.Benchmarks.Runner/App.Metrics.Benchmarks.Runner.csproj
+++ b/src/Core/benchmarks/App.Metrics.Benchmarks.Runner/App.Metrics.Benchmarks.Runner.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/benchmarks/App.Metrics.Benchmarks/App.Metrics.Benchmarks.csproj
+++ b/src/Core/benchmarks/App.Metrics.Benchmarks/App.Metrics.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/build/build.csproj
+++ b/src/Core/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/sandbox/MetricsSandbox/MetricsSandbox.csproj
+++ b/src/Core/sandbox/MetricsSandbox/MetricsSandbox.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Core/test/Directory.Build.props
+++ b/src/Core/test/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AppMetricsConcurrencyVersion>2.0.1</AppMetricsConcurrencyVersion>
     <AppMetricsVersion>4.0.0-*</AppMetricsVersion>
-    <FrameworkVersion>3.0.0</FrameworkVersion>
+    <FrameworkVersion>3.1.0</FrameworkVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -53,16 +53,6 @@
     <PackageReference Update="App.Metrics.AspNetCore.Tracking" Version="$(AppMetricsVersion)" />
     
     <!-- Microsoft -->
-    <PackageReference Update="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc." Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="$(FrameworkVersion)" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="$(FrameworkVersion)" />
-    <PackageReference Update="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Routing" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(FrameworkVersion)" />
@@ -86,6 +76,19 @@
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.4.0" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Update="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc." Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="$(FrameworkVersion)" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="$(FrameworkVersion)" />
+    <PackageReference Update="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Routing" Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
   </ItemGroup>
 
   <Target Name="SetAssemblyVersion" AfterTargets="MinVer">

--- a/src/Extensions/build/build.csproj
+++ b/src/Extensions/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Extensions/sandbox/HealthHostingMicrosoftExtensionsSandbox/HealthHostingMicrosoftExtensionsSandbox.csproj
+++ b/src/Extensions/sandbox/HealthHostingMicrosoftExtensionsSandbox/HealthHostingMicrosoftExtensionsSandbox.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
 

--- a/src/Extensions/sandbox/HealthMicrosoftExtensionsSandbox/HealthMicrosoftExtensionsSandbox.csproj
+++ b/src/Extensions/sandbox/HealthMicrosoftExtensionsSandbox/HealthMicrosoftExtensionsSandbox.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,10 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics.Health" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Extensions/sandbox/MetricsHostingMicrosoftExtensionsSandbox/MetricsHostingMicrosoftExtensionsSandbox.csproj
+++ b/src/Extensions/sandbox/MetricsHostingMicrosoftExtensionsSandbox/MetricsHostingMicrosoftExtensionsSandbox.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Extensions/sandbox/MetricsMicrosoftExtensionsSandbox/MetricsMicrosoftExtensionsSandbox.csproj
+++ b/src/Extensions/sandbox/MetricsMicrosoftExtensionsSandbox/MetricsMicrosoftExtensionsSandbox.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
@@ -17,10 +17,10 @@
   </ItemGroup>
   <ItemGroup>
 	<PackageReference Include="App.Metrics" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-	<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\App.Metrics.Extensions.Configuration\App.Metrics.Extensions.Configuration.csproj" />

--- a/src/Extensions/test/Directory.Build.props
+++ b/src/Extensions/test/Directory.Build.props
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="FluentAssertions" />

--- a/src/Reporting/build/build.csproj
+++ b/src/Reporting/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandbox/GrafanaCloudHostedMetricsSandbox.csproj
+++ b/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandbox/GrafanaCloudHostedMetricsSandbox.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandboxMvc/GrafanaCloudHostedMetricsSandboxMvc.csproj
+++ b/src/Reporting/sandbox/GrafanaCloudHostedMetricsSandboxMvc/GrafanaCloudHostedMetricsSandboxMvc.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore.Mvc" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.1.0" />

--- a/src/Reporting/sandbox/MetricsGraphiteSandbox/MetricsGraphiteSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsGraphiteSandbox/MetricsGraphiteSandbox.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/Reporting/sandbox/MetricsGraphiteSandboxMvc/MetricsGraphiteSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsGraphiteSandboxMvc/MetricsGraphiteSandboxMvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>        

--- a/src/Reporting/sandbox/MetricsInfluxDBSandbox/MetricsInfluxDBSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsInfluxDBSandbox/MetricsInfluxDBSandbox.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Reporting/sandbox/MetricsInfluxDBSandboxMvc/MetricsInfluxDBSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsInfluxDBSandboxMvc/MetricsInfluxDBSandboxMvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Reporting/sandbox/MetricsPrometheusSandboxMvc/MetricsPrometheusSandboxMvc.csproj
+++ b/src/Reporting/sandbox/MetricsPrometheusSandboxMvc/MetricsPrometheusSandboxMvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reporting/sandbox/MetricsReceiveSanboxApi/MetricsReceiveSanboxApi.csproj
+++ b/src/Reporting/sandbox/MetricsReceiveSanboxApi/MetricsReceiveSanboxApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reporting/sandbox/ReportingSandbox/ReportingSandbox.csproj
+++ b/src/Reporting/sandbox/ReportingSandbox/ReportingSandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Reporting/test/Directory.Build.props
+++ b/src/Reporting/test/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
+      <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### The issue or feature being addressed

* #521

Attempt at bringing these solutions up to .NET Core 3.1

### Details on the issue fix or feature implementation

* All 3.0 -> 3.1
* For AspNetCore packages multitarget netstandard2.0 and netcoreapp3.1
  * For netstandard2.0: keep packagereference to 2.x AspNetCore packages
  * For netcoreapp3.1: use the frameworkreference

Tests are green, and have tested the AspNetCore sanbox projects and they work as far as I can see.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
