### PR TITLE
Handle exceptions in ASPNET Core tracking middleware

### DIFF
--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ActiveRequestCounterEndpointMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ActiveRequestCounterEndpointMiddleware.cs
@@ -38,15 +38,10 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
             try
             {
                 await _next(context);
-                _metrics.DecrementActiveRequests();
-            }
-            catch (Exception)
-            {
-                _metrics.DecrementActiveRequests();
-                throw;
             }
             finally
             {
+                _metrics.DecrementActiveRequests();
                 _logger.MiddlewareExecuted<ActiveRequestCounterEndpointMiddleware>();
             }
         }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ApdexMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ApdexMiddleware.cs
@@ -16,7 +16,6 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
     public class ApdexMiddleware
         // ReSharper restore ClassNeverInstantiated.Global
     {
-        private const string ApdexItemsKey = "__App.Metrics.Apdex__";
         private readonly RequestDelegate _next;
         private readonly ILogger<ApdexMiddleware> _logger;
         private readonly IApdex _apdexTracking;
@@ -40,19 +39,18 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         {
             _logger.MiddlewareExecuting<ApdexMiddleware>();
 
-            context.Items[ApdexItemsKey] = _apdexTracking.NewContext();
-
-            await _next(context);
-
-            var apdex = context.Items[ApdexItemsKey];
-
-            using (apdex as IDisposable)
+            try
             {
+                using (_apdexTracking.NewContext())
+                {
+                    await _next(context);
+                }
             }
+            finally
+            {
 
-            context.Items.Remove(ApdexItemsKey);
-
-            _logger.MiddlewareExecuted<ApdexMiddleware>();
+                _logger.MiddlewareExecuted<ApdexMiddleware>();
+            }
         }
     }
 }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
@@ -38,19 +38,17 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         {
             _logger.MiddlewareExecuting<RequestTimerMiddleware>();
 
-            context.Items[TimerItemsKey] = _requestTimer.NewContext();
-
-            await _next(context);
-
-            var timer = context.Items[TimerItemsKey];
-
-            using (timer as IDisposable)
+            try
             {
+                using (_requestTimer.NewContext())
+                {
+                    await _next(context);
+                }
             }
-
-            context.Items.Remove(TimerItemsKey);
-
-            _logger.MiddlewareExecuted<RequestTimerMiddleware>();
+            finally
+            {
+                _logger.MiddlewareExecuted<RequestTimerMiddleware>();
+            }
         }
     }
 }

--- a/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/RequestTimerMiddlewareTests.cs
+++ b/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/RequestTimerMiddlewareTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading.Tasks;
+using App.Metrics.AspNetCore.Tracking.Middleware;
+using App.Metrics.Timer;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using ITimer = App.Metrics.Timer.ITimer;
+
+namespace App.Metrics.AspNetCore.Tracking.Facts.Middleware
+{
+    public class RequestTimerMiddlewareTests : IDisposable
+    {
+        private Mock<ITimer> _mockTimer;
+        private Mock<IProvideTimerMetrics> _mockTimerMetrics;
+        private Mock<IMetrics> _mockMetrics;
+
+        public RequestTimerMiddlewareTests() {
+
+            _mockMetrics = new Mock<IMetrics>();
+            var mockProvider = new Mock<IProvideMetrics>();
+            _mockTimer = new Mock<ITimer>();
+            _mockTimerMetrics = new Mock<IProvideTimerMetrics>();
+
+
+            _mockMetrics.Setup(_ => _.Provider).Returns(mockProvider.Object);
+            mockProvider.Setup(_ => _.Timer).Returns(_mockTimerMetrics.Object);
+            _mockTimerMetrics.Setup(_ => _.Instance(It.IsAny<TimerOptions>())).Returns(_mockTimer.Object).Verifiable("Timer was not created.");
+            _mockTimer.Setup(_ => _.NewContext()).Returns(new TimerContext(_mockTimer.Object, null));
+        }
+
+        private RequestTimerMiddleware CreateMiddleware(RequestDelegate next)
+        {
+            return new RequestTimerMiddleware(next, new Mock<ILogger<RequestTimerMiddleware>>().Object, _mockMetrics.Object);
+        }
+
+        [Fact]
+        public async Task Middleware_starts_a_timer_before_invocation_of_next_and_ends_after_completion()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            
+            var sut = CreateMiddleware(context => tcs.Task);
+
+            var invocation =  sut.Invoke(new DefaultHttpContext());
+
+            _mockTimer.Verify(_ => _.StartRecording(), Times.Once);
+            _mockTimer.Verify(_ => _.EndRecording(), Times.Never);
+
+            tcs.SetResult(true);
+
+            await invocation;
+
+            _mockTimer.Verify(_ => _.StartRecording(), Times.Once);
+            _mockTimer.Verify(_ => _.EndRecording(), Times.Once);
+        }
+
+        [Fact]
+        public void An_erroring_next_still_closes_the_timer_session()
+        {
+            var expectedException = new Exception("Test error");
+
+            var sut = CreateMiddleware(context => Task.FromException(expectedException));
+
+            Func<Task> act = () => sut.Invoke(new DefaultHttpContext());
+
+            act.Should().Throw<Exception>().Which.IsSameOrEqualTo(expectedException);
+
+            _mockTimer.Verify(_ => _.StartRecording(), Times.Once);
+            _mockTimer.Verify(_ => _.EndRecording(), Times.Once);
+        }
+
+        public void Dispose()
+        {
+            _mockTimerMetrics.Verify();
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

#468 

### Details on the issue fix or feature implementation

The referenced issue highlights a problem with the ASPNET Core middlewares. If an exception is thrown further down the pipeline, AppMetrics is not handling it. Therefore, timers are left running and counters become inaccurate. 

This PR adds a finally block to all tracking ASPNET Core middlewares to ensure timers are stopped, counters are decremented, and logging is completed. There is a test fixture for the middleware mentioned in the issue. I ran out of time to copy it for the others.

I did run the code clean up using the supplied profile, but it mostly changed code I hadn't touched. Therefore, I'll leave it up to someone else.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits