### PR TITLE
Add ability to record a timer using a user supplied value. Fixes #304

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/Timer/IMeasureTimerMetrics.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Timer/IMeasureTimerMetrics.cs
@@ -90,5 +90,22 @@ namespace App.Metrics.Timer
         /// <param name="options">The details of the timer that is being measured</param>
         /// <returns>A disposable context, when disposed records the time token to process the using block</returns>
         TimerContext Time(TimerOptions options);
+
+        /// <summary>
+        /// Records a <see cref="ITimerMetric" /> which records the user generated time taken. This can be useful
+        /// for an external service that you want to capture its observed duration.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="tags"></param>
+        /// <param name="time"></param>
+        void Time(TimerOptions options, MetricTags tags, long time);
+
+        /// <summary>
+        /// Records a <see cref="ITimerMetric" /> which records the user generated time taken. This can be useful
+        /// for an external service that you want to capture its observed duration.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="time"></param>
+        void Time(TimerOptions options, long time);
     }
 }

--- a/src/Core/src/App.Metrics.Core/Timer/DefaultTimerManager.cs
+++ b/src/Core/src/App.Metrics.Core/Timer/DefaultTimerManager.cs
@@ -123,5 +123,23 @@ namespace App.Metrics.Timer
                                      _clock)).
                              NewContext(userValue);
         }
+
+        public void Time(TimerOptions options, long time)
+        {
+            var context = _registry.Timer(options,
+                                () => _timerBuilder.Build(
+                                     options.Reservoir,
+                                     _clock));
+            context.Record(time, options.DurationUnit);
+        }
+
+        public void Time(TimerOptions options, MetricTags tags, long time)
+        {
+            var context = _registry.Timer(options, tags, 
+                                () => _timerBuilder.Build(
+                                     options.Reservoir,
+                                     _clock));
+            context.Record(time, options.DurationUnit);
+        }
     }
 }

--- a/src/Core/test/App.Metrics.Facts/Managers/DefaultTimerManagerTests.cs
+++ b/src/Core/test/App.Metrics.Facts/Managers/DefaultTimerManagerTests.cs
@@ -99,6 +99,19 @@ namespace App.Metrics.Facts.Managers
         }
 
         [Fact]
+        public void Can_time_with_specified_value()
+        {
+            var metricName = "test_manager_timer_specified_value";
+            var options = new TimerOptions { Name = metricName };
+
+            _manager.Time(options, 250);
+
+            var timerValue = _fixture.Snapshot.GetTimerValue(_fixture.Context, metricName);
+
+            timerValue.Histogram.Sum.Should().Be(250.0);
+        }
+
+        [Fact]
         public void Can_time_in_using_when_multidimensional()
         {
             var metricName = "test_manager_timer_using_multi";


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/master/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

#304 

### Details on the issue fix or feature implementation

This one should be self explanatory, I would like to record timers with a user supplied values.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
