### PR TITLE
GH550: Add netcoreapp3.1 target framework

### DIFF
--- a/build/shared.props
+++ b/build/shared.props
@@ -13,6 +13,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
  		<PublishRepositoryUrl>true</PublishRepositoryUrl>
     	<EmbedUntrackedSources>true</EmbedUntrackedSources>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test", "benchmarks", "sandbox" ],
   "sdk": {
-    "version": "3.1.201"
+    "version": "3.1.202"
   }
 }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc.Core/App.Metrics.AspNetCore.Mvc.Core.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc.Core/App.Metrics.AspNetCore.Mvc.Core.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core MVC Core features such as metric tracking on controller actions using attribute routes.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;aspnetcoremvc;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
   </ItemGroup>
 

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc.Core/MvcRouteTemplateResolver.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc.Core/MvcRouteTemplateResolver.cs
@@ -29,6 +29,12 @@ namespace Microsoft.AspNetCore.Mvc.Internal
             _routeNameResolver = routeNameResolver ?? throw new ArgumentNullException(nameof(routeNameResolver));
         }
 
+#if NETCOREAPP
+        public Task<string> ResolveMatchingTemplateRouteAsync(RouteData routeData)
+        {
+            return Task.FromResult(string.Empty);
+        }
+#else
         public async Task<string> ResolveMatchingTemplateRouteAsync(RouteData routeData)
         {
             var templateRoute = await _routeNameResolver.ResolveMatchingTemplateRouteAsync(routeData).ConfigureAwait(false);
@@ -98,5 +104,6 @@ namespace Microsoft.AspNetCore.Mvc.Internal
 
             return routeTemplate;
         }
+#endif
     }
 }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc/App.Metrics.AspNetCore.Mvc.csproj
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Mvc/App.Metrics.AspNetCore.Mvc.csproj
@@ -2,12 +2,16 @@
 
   <PropertyGroup>
     <Description>App Metrics ASP.NET Core MVC features such as metric tracking on controller actions using attribute routes.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <PackageTags>appmetrics;aspnetcore;aspnetcoremvc;metrics</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -59,7 +59,6 @@
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(FrameworkVersion)" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
 
     <!-- Tests -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.3.0" />
@@ -74,7 +73,7 @@
     <PackageReference Update="SimpleExec" Version="6.1.0" />
     <PackageReference Update="Bullseye" Version="3.0.0" />
     <PackageReference Update="McMaster.Extensions.CommandLineUtils" Version="2.4.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -51,7 +51,7 @@
     <PackageReference Update="App.Metrics.AspNetCore.Reporting" Version="$(AppMetricsVersion)" />
     <PackageReference Update="App.Metrics.AspNetCore.Routing" Version="$(AppMetricsVersion)" />
     <PackageReference Update="App.Metrics.AspNetCore.Tracking" Version="$(AppMetricsVersion)" />
-    
+
     <!-- Microsoft -->
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="$(FrameworkVersion)" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(FrameworkVersion)" />
@@ -80,7 +80,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Update="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc." Version="2.2.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Http.Extensions" Version="$(FrameworkVersion)" />


### PR DESCRIPTION
### The issue or feature being addressed

Fixes #550.

### Details on the issue fix or feature implementation

* Change relevant libraries to multi-target netcoreapp3.1
* Implements workaround alluded to in #519 since it did not _compile_ for netcoreapp3.1

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
