### PR TITLE
Contextual tags

### DIFF
--- a/src/Core/benchmarks/App.Metrics.Benchmarks/BenchmarkDotNetBenchmarks/Metrics/DefaultMetricContextRegistryBenchmark.cs
+++ b/src/Core/benchmarks/App.Metrics.Benchmarks/BenchmarkDotNetBenchmarks/Metrics/DefaultMetricContextRegistryBenchmark.cs
@@ -14,6 +14,7 @@ using App.Metrics.ReservoirSampling;
 using App.Metrics.ReservoirSampling.ExponentialDecay;
 using App.Metrics.Timer;
 using BenchmarkDotNet.Attributes;
+using System;
 
 namespace App.Metrics.Benchmarks.BenchmarkDotNetBenchmarks.Metrics
 {
@@ -75,7 +76,13 @@ namespace App.Metrics.Benchmarks.BenchmarkDotNetBenchmarks.Metrics
                            { "key2", "value2" }
                        };
 
-            _registry = new DefaultMetricContextRegistry("context_label", tags);
+            var contextualTags = new ContextualMetricTagProviders
+                       {
+                           { "key1", () => new Guid().ToString() },
+                           { "key2", () => new Guid().ToString() }
+                       };
+
+            _registry = new DefaultMetricContextRegistry("context_label", tags, contextualTags);
         }
 
         [Benchmark]

--- a/src/Core/benchmarks/App.Metrics.Benchmarks/Fixtures/MetricContextTestFixture.cs
+++ b/src/Core/benchmarks/App.Metrics.Benchmarks/Fixtures/MetricContextTestFixture.cs
@@ -57,9 +57,15 @@ namespace App.Metrics.Benchmarks.Fixtures
                            { "key2", "value2" }
                        };
 
+            var contextualTags = new ContextualMetricTagProviders
+                       {
+                           { "key1", () => new Guid().ToString() },
+                           { "key2", () => new Guid().ToString() }
+                       };
+
             var samplingProvider = new DefaultSamplingReservoirProvider(() => new DefaultForwardDecayingReservoir());
 
-            Registry = new DefaultMetricContextRegistry("context_label", tags);
+            Registry = new DefaultMetricContextRegistry("context_label", tags, contextualTags);
             ApdexBuilder = new DefaultApdexBuilder(samplingProvider);
             HistogramBuilder = new DefaultHistogramBuilder(samplingProvider);
             CounterBuilder = new DefaultCounterBuilder();

--- a/src/Core/src/App.Metrics.Abstractions/ContextualMetricTagProviders.cs
+++ b/src/Core/src/App.Metrics.Abstractions/ContextualMetricTagProviders.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="ContextualMetricTags.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace App.Metrics
+{
+    public class ContextualMetricTagProviders : Dictionary<string, Func<string>>
+    {
+        public ContextualMetricTagProviders(Dictionary<string, Func<string>> tagProviders)
+            : base(tagProviders) { }
+
+        public ContextualMetricTagProviders() { }
+
+        public Dictionary<string, string> ComputeTagValues()
+        {
+            return this.ToDictionary(pair => pair.Key, pair => pair.Value());
+        }
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/MetricsOptions.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricsOptions.cs
@@ -31,6 +31,14 @@ namespace App.Metrics
         public GlobalMetricTags GlobalTags { get; set; } = new GlobalMetricTags();
 
         /// <summary>
+        ///     Gets or sets the contextual tags to apply on all metrics when reporting.
+        /// </summary>
+        /// <value>
+        ///     The contextual tags applied to on all metrics when reporting.
+        /// </value>
+        public ContextualMetricTagProviders ContextualTags { get; set; } = new ContextualMetricTagProviders();
+
+        /// <summary>
         ///     Gets or sets a value indicating whether [metrics tracking enabled]. This will also avoid registering all metric
         ///     tracking middleware if using App.Metrics.Middleware.
         /// </summary>

--- a/src/Core/src/App.Metrics.Core/Builder/MetricsBuilder.cs
+++ b/src/Core/src/App.Metrics.Core/Builder/MetricsBuilder.cs
@@ -213,7 +213,10 @@ namespace App.Metrics
                 _metricsReportRunner);
 
             IMetricContextRegistry ContextRegistry(string context) =>
-                new DefaultMetricContextRegistry(context, new GlobalMetricTags(_options.GlobalTags));
+                new DefaultMetricContextRegistry(
+                    context,
+                    new GlobalMetricTags(_options.GlobalTags),
+                    new ContextualMetricTagProviders(_options.ContextualTags));
         }
 
         public bool CanReport() { return _options.Enabled && _options.ReportingEnabled && _reporters.Any(); }

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricContextRegistry.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricContextRegistry.cs
@@ -32,6 +32,8 @@ namespace App.Metrics.Internal
 
         private readonly GlobalMetricTags _globalTags;
 
+        private readonly ContextualMetricTagProviders _contextualTags;
+
         private readonly MetricMetaCatalog<IHistogram, HistogramValueSource, HistogramValue> _histograms =
             new MetricMetaCatalog<IHistogram, HistogramValueSource, HistogramValue>();
 
@@ -42,13 +44,14 @@ namespace App.Metrics.Internal
             new MetricMetaCatalog<ITimer, TimerValueSource, TimerValue>();
 
         public DefaultMetricContextRegistry(string context)
-            : this(context, new GlobalMetricTags())
+            : this(context, new GlobalMetricTags(), new ContextualMetricTagProviders())
         {
         }
 
-        public DefaultMetricContextRegistry(string context, GlobalMetricTags globalTags)
+        public DefaultMetricContextRegistry(string context, GlobalMetricTags globalTags, ContextualMetricTagProviders contextualTags)
         {
             _globalTags = globalTags ?? throw new ArgumentNullException(nameof(globalTags));
+            _contextualTags = contextualTags ?? throw new ArgumentNullException(nameof(contextualTags));
 
             if (context.IsMissing())
             {
@@ -368,7 +371,12 @@ namespace App.Metrics.Internal
                 });
         }
 
-        private MetricTags AllTags(MetricTags metricTags) { return MetricTags.Concat(metricTags, _globalTags); }
+        private MetricTags AllTags(MetricTags metricTags)
+        {
+            return MetricTags.Concat(
+                MetricTags.Concat(metricTags, _globalTags),
+                _contextualTags.ComputeTagValues());
+        }
 
         private sealed class MetricMetaCatalog<TMetric, TValue, TMetricValue>
             where TValue : MetricValueSourceBase<TMetricValue>

--- a/src/Core/src/App.Metrics.Core/Internal/Extensions/MetricsOptionsExtensions.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/Extensions/MetricsOptionsExtensions.cs
@@ -26,6 +26,16 @@ namespace App.Metrics.Internal.Extensions
                 }
             }
 
+            foreach (var contextualTag in options.ContextualTags)
+            {
+                var key = $"{KeyValuePairMetricsOptions.ContextualTagsDirective}:{contextualTag.Key}";
+
+                if (!result.ContainsKey(key))
+                {
+                    result.Add(key, "<computed>");
+                }
+            }
+
             return result;
         }
     }

--- a/src/Core/src/App.Metrics.Core/Internal/KeyValuePairMetricsOptions.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/KeyValuePairMetricsOptions.cs
@@ -14,6 +14,7 @@ namespace App.Metrics.Internal
         internal static readonly string EnabledDirective = $"{nameof(MetricsOptions)}:{nameof(MetricsOptions.Enabled)}";
         internal static readonly string ReportingEnabledDirective = $"{nameof(MetricsOptions)}:{nameof(MetricsOptions.ReportingEnabled)}";
         internal static readonly string GlobalTagsDirective = $"{nameof(MetricsOptions)}:{nameof(MetricsOptions.GlobalTags)}:";
+        internal static readonly string ContextualTagsDirective = $"{nameof(MetricsOptions)}:{nameof(MetricsOptions.ContextualTags)}:";
         private readonly MetricsOptions _options;
 
         private readonly Dictionary<string, string> _optionValues;


### PR DESCRIPTION
### The issue or feature being addressed

- Adding contextual tags for all metrics (resolving #334)

### Details on the issue fix or feature implementation

- Add contextual tags to MetricsOptions in a very similar manner to global tags, but with computed values (Func<string>) instead of string values

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
    - There were no tests for GlobalMetricTags so I didn't add any new ones
- [x] I have included the github issue number in my commits
