### PR TITLE
Add behaviour to ASP.NET Core middleware when IsWebSocketRequests.

### DIFF
--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/Extensions/MetricsExtensions.cs
@@ -35,6 +35,24 @@ namespace App.Metrics
         }
 
         /// <summary>
+        ///     Increments the number of active active web socket requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        public static void IncrementActiveWSRequests(this IMetrics metrics)
+        {
+            metrics.Measure.Counter.Increment(HttpRequestMetricsRegistry.Counters.ActiveWebSocketRequestCount);
+        }
+
+        /// <summary>
+        ///     Decrements the number of active web socket requests.
+        /// </summary>
+        /// <param name="metrics">The metrics.</param>
+        public static void DecrementActiveWSRequests(this IMetrics metrics)
+        {
+            metrics.Measure.Counter.Decrement(HttpRequestMetricsRegistry.Counters.ActiveWebSocketRequestCount);
+        }
+
+        /// <summary>
         ///     Records metrics about a Clients HTTP request error, counts the total number of errors for each status code,
         ///     measures the
         ///     rate and percentage of HTTP error requests tagging by client id (if it exists) the endpoints route template and

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Core/Internal/HttpRequestMetricsRegistry.cs
@@ -40,6 +40,13 @@ namespace App.Metrics.AspNetCore.Internal
                                                                            MeasurementUnit = Unit.Custom("Active Requests")
                                                                        };
 
+            public static readonly CounterOptions ActiveWebSocketRequestCount = new CounterOptions
+                                                                                {
+                                                                                    Context = ContextName,
+                                                                                    Name = "Active Web Sockets",
+                                                                                    MeasurementUnit = Unit.Custom("Active Requests")
+                                                                                };
+
             public static readonly CounterOptions TotalErrorRequestCount = new CounterOptions
                                                                            {
                                                                                Context = ContextName,

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ActiveRequestCounterEndpointMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ActiveRequestCounterEndpointMiddleware.cs
@@ -33,7 +33,15 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         {
             _logger.MiddlewareExecuting<ActiveRequestCounterEndpointMiddleware>();
 
-            _metrics.IncrementActiveRequests();
+            var isWebSocketRequest = context.WebSockets.IsWebSocketRequest;
+            if (isWebSocketRequest)
+            {
+                _metrics.IncrementActiveWSRequests();
+            }
+            else
+            {
+                _metrics.IncrementActiveRequests();
+            }
 
             try
             {
@@ -41,7 +49,15 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
             }
             finally
             {
-                _metrics.DecrementActiveRequests();
+                if (isWebSocketRequest)
+                {
+                    _metrics.DecrementActiveWSRequests();
+                }
+                else
+                {
+                    _metrics.DecrementActiveRequests();
+                }
+
                 _logger.MiddlewareExecuted<ActiveRequestCounterEndpointMiddleware>();
             }
         }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ApdexMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/ApdexMiddleware.cs
@@ -34,8 +34,18 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         }
 
         // ReSharper disable UnusedMember.Global
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
             // ReSharper restore UnusedMember.Global
+        {
+            if (!context.WebSockets.IsWebSocketRequest)
+            {
+                return _next(context);
+            }
+
+            return MeasureTransaction(context);
+        }
+
+        private async Task MeasureTransaction(HttpContext context)
         {
             _logger.MiddlewareExecuting<ApdexMiddleware>();
 
@@ -48,7 +58,6 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
             }
             finally
             {
-
                 _logger.MiddlewareExecuted<ApdexMiddleware>();
             }
         }

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/PerRequestTimerMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/PerRequestTimerMiddleware.cs
@@ -16,7 +16,6 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
     public class PerRequestTimerMiddleware
         // ReSharper restore ClassNeverInstantiated.Global
     {
-        private const string TimerItemsKey = "__App.Metrics.PerRequestStartTime__";
         private readonly RequestDelegate _next;
         private readonly ILogger<PerRequestTimerMiddleware> _logger;
         private readonly IMetrics _metrics;
@@ -35,8 +34,18 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         }
 
         // ReSharper disable UnusedMember.Global
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
             // ReSharper restore UnusedMember.Global
+        {
+            if (context.WebSockets.IsWebSocketRequest)
+            {
+                return _next(context);
+            }
+
+            return TimeTransaction(context);
+        }
+
+        private async Task TimeTransaction(HttpContext context)
         {
             _logger.MiddlewareExecuting<PerRequestTimerMiddleware>();
 

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Middleware/RequestTimerMiddleware.cs
@@ -15,7 +15,6 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
     public class RequestTimerMiddleware
         // ReSharper restore ClassNeverInstantiated.Global
     {
-        private const string TimerItemsKey = "__App.Metrics.RequestTimer__";
         private readonly ILogger<RequestTimerMiddleware> _logger;
         private readonly RequestDelegate _next;
         private readonly ITimer _requestTimer;
@@ -33,8 +32,18 @@ namespace App.Metrics.AspNetCore.Tracking.Middleware
         }
 
         // ReSharper disable UnusedMember.Global
-        public async Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context)
             // ReSharper restore UnusedMember.Global
+        {
+            if (context.WebSockets.IsWebSocketRequest)
+            {
+                return _next(context);
+            }
+
+            return TimeTransaction(context);
+        }
+
+        private async Task TimeTransaction(HttpContext context)
         {
             _logger.MiddlewareExecuting<RequestTimerMiddleware>();
 

--- a/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/ActiveRequestCounterEndpointMiddlewareTests.cs
+++ b/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/ActiveRequestCounterEndpointMiddlewareTests.cs
@@ -1,0 +1,114 @@
+﻿// <copyright file="ActiveRequestCounterEndpointMiddlewareTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using App.Metrics.AspNetCore.Tracking.Middleware;
+using App.Metrics.Counter;
+using FluentAssertions;
+using FluentAssertions.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace App.Metrics.AspNetCore.Tracking.Facts.Middleware
+{
+    public class ActiveRequestCounterEndpointMiddlewareTests
+    {
+        private static Expression<Func<CounterOptions, bool>> WithActiveName() => counterOptions => counterOptions.Name == "Active";
+        private static Expression<Func<CounterOptions, bool>> WithActiveWebSocketName() => counterOptions => counterOptions.Name == "Active Web Sockets";
+
+
+        private readonly Mock<IMetrics> _mockMetrics;
+        private readonly Mock<IMeasureCounterMetrics> _mockCounterMetrics;
+
+        public ActiveRequestCounterEndpointMiddlewareTests() {
+            _mockMetrics = new Mock<IMetrics>();
+
+            var mockMeasure = new Mock<IMeasureMetrics>();
+            _mockMetrics.Setup(_ => _.Measure).Returns(mockMeasure.Object);
+            _mockCounterMetrics = new Mock<IMeasureCounterMetrics>();
+            mockMeasure.Setup(_ => _.Counter).Returns(_mockCounterMetrics.Object);
+        }
+
+        [Fact]
+        public async Task Middleware_increments_count_before_invoke_and_decrements_after_invoke()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            
+            var sut = CreateMiddleware(context => tcs.Task);
+
+            var invocation =  sut.Invoke(new DefaultHttpContext());
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveName())), Times.Once);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveName())), Times.Never);
+
+            tcs.SetResult(true);
+
+            await invocation;
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveName())), Times.Once);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveName())), Times.Once);
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Never);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Never);
+        }
+
+        [Fact]
+        public void An_erroring_next_still_decrements_active_count()
+        {
+            var expectedException = new Exception("Test error");
+
+            var sut = CreateMiddleware(context => Task.FromException(expectedException));
+
+            Func<Task> act = () => sut.Invoke(new DefaultHttpContext());
+
+            act.Should().Throw<Exception>().Which.IsSameOrEqualTo(expectedException);
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveName())), Times.Once);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveName())), Times.Once);
+        }
+
+        [Fact]
+        public async Task Middleware_tracks_web_socket_requests_separately()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            var sut = CreateMiddleware(context => tcs.Task);
+
+            var invocation = sut.Invoke(CreateWebSocketRequest());
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Once);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Never);
+
+            tcs.SetResult(true);
+
+            await invocation;
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Once);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveWebSocketName())), Times.Once);
+
+            _mockCounterMetrics.Verify(_ => _.Increment(It.Is<CounterOptions>(WithActiveName())), Times.Never);
+            _mockCounterMetrics.Verify(_ => _.Decrement(It.Is<CounterOptions>(WithActiveName())), Times.Never);
+
+        }
+
+        private static DefaultHttpContext CreateWebSocketRequest()
+        {
+            var mockWebSocketFeature = new Mock<IHttpWebSocketFeature>();
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set(mockWebSocketFeature.Object);
+            mockWebSocketFeature.SetupGet(_ => _.IsWebSocketRequest).Returns(true);
+            return new DefaultHttpContext(featureCollection);
+        }
+
+        private ActiveRequestCounterEndpointMiddleware CreateMiddleware(RequestDelegate next)
+        {
+            return new ActiveRequestCounterEndpointMiddleware(next, new Mock<ILogger<ActiveRequestCounterEndpointMiddleware>>().Object, _mockMetrics.Object);
+        }
+    }
+}

--- a/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/RequestTimerMiddlewareTests.cs
+++ b/src/AspNetCore/test/App.Metrics.AspNetCore.Tracking.Facts/Middleware/RequestTimerMiddlewareTests.cs
@@ -1,10 +1,15 @@
-﻿using System;
+﻿// <copyright file="RequestTimerMiddlewareTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
 using System.Threading.Tasks;
 using App.Metrics.AspNetCore.Tracking.Middleware;
 using App.Metrics.Timer;
 using FluentAssertions;
 using FluentAssertions.Common;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -14,9 +19,9 @@ namespace App.Metrics.AspNetCore.Tracking.Facts.Middleware
 {
     public class RequestTimerMiddlewareTests : IDisposable
     {
-        private Mock<ITimer> _mockTimer;
-        private Mock<IProvideTimerMetrics> _mockTimerMetrics;
-        private Mock<IMetrics> _mockMetrics;
+        private readonly Mock<ITimer> _mockTimer;
+        private readonly Mock<IProvideTimerMetrics> _mockTimerMetrics;
+        private readonly Mock<IMetrics> _mockMetrics;
 
         public RequestTimerMiddlewareTests() {
 
@@ -25,16 +30,10 @@ namespace App.Metrics.AspNetCore.Tracking.Facts.Middleware
             _mockTimer = new Mock<ITimer>();
             _mockTimerMetrics = new Mock<IProvideTimerMetrics>();
 
-
             _mockMetrics.Setup(_ => _.Provider).Returns(mockProvider.Object);
             mockProvider.Setup(_ => _.Timer).Returns(_mockTimerMetrics.Object);
             _mockTimerMetrics.Setup(_ => _.Instance(It.IsAny<TimerOptions>())).Returns(_mockTimer.Object).Verifiable("Timer was not created.");
-            _mockTimer.Setup(_ => _.NewContext()).Returns(new TimerContext(_mockTimer.Object, null));
-        }
-
-        private RequestTimerMiddleware CreateMiddleware(RequestDelegate next)
-        {
-            return new RequestTimerMiddleware(next, new Mock<ILogger<RequestTimerMiddleware>>().Object, _mockMetrics.Object);
+            _mockTimer.Setup(_ => _.NewContext()).Returns(() => new TimerContext(_mockTimer.Object, null));
         }
 
         [Fact]
@@ -70,6 +69,40 @@ namespace App.Metrics.AspNetCore.Tracking.Facts.Middleware
 
             _mockTimer.Verify(_ => _.StartRecording(), Times.Once);
             _mockTimer.Verify(_ => _.EndRecording(), Times.Once);
+        }
+
+        [Fact]
+        public async Task Middleware_ignores_web_socket_requests()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            var sut = CreateMiddleware(context => tcs.Task);
+
+            var invocation = sut.Invoke(CreateWebSocketRequest());
+
+            _mockTimer.Verify(_ => _.StartRecording(), Times.Never);
+            _mockTimer.Verify(_ => _.EndRecording(), Times.Never);
+
+            tcs.SetResult(true);
+
+            await invocation;
+
+            _mockTimer.Verify(_ => _.StartRecording(), Times.Never);
+            _mockTimer.Verify(_ => _.EndRecording(), Times.Never);
+        }
+
+        private static DefaultHttpContext CreateWebSocketRequest()
+        {
+            var mockWebSocketFeature = new Mock<IHttpWebSocketFeature>();
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set(mockWebSocketFeature.Object);
+            mockWebSocketFeature.SetupGet(_ => _.IsWebSocketRequest).Returns(true);
+            return new DefaultHttpContext(featureCollection);
+        }
+
+        private RequestTimerMiddleware CreateMiddleware(RequestDelegate next)
+        {
+            return new RequestTimerMiddleware(next, new Mock<ILogger<RequestTimerMiddleware>>().Object, _mockMetrics.Object);
         }
 
         public void Dispose()


### PR DESCRIPTION
Filter web socket requests from timer and APDEX middleware.
Count active web sockets in a separate counter.

Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/master/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

Fixes #545 

Apologies for the delay since saying I'd do this.

### Details on the issue fix or feature implementation

The middleware now uses IsWebSocketRequest to keep different metrics for web sockets, which are usually very long lived transactions. Primarily request timers ignore web sockets and active web socket requests are tracked in a separate counter.

The IsWebSocketRequest flag is only correct if the WebSocketMiddleware has already executed in the pipeline. Therefore, it is still up to users to ensure UseWebSockets is called before UseMetricsAllMiddleware. I toyed with having an additional method like UseMetricsAllMiddlewareWithWebSockets, but due to the options on UseWebSockets it seemed messy. Happy to add if it will make usage slightly clearer.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits
