### PR TITLE
have global.json target .NET Core 3.1 generally, not a specific SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test", "benchmarks", "sandbox" ],
   "sdk": {
-    "version": "3.1.202"
+    "version": "3.1"
   }
 }


### PR DESCRIPTION
close #565

### Details on the issue fix or feature implementation
Makes `global.json` forward compatible with new versions of the .NET Core 3.1 SDK.


### Confirm the following

- [ x] I have ensured that I have merged the latest changes from the dev branch
- [ x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ x] I have included the github issue number in my commits
