### PR TITLE
#497 Allow metrics on custom port with custom host configuration

### DIFF
--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointHostBuilderExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointHostBuilderExtensions.cs
@@ -129,43 +129,28 @@ namespace Microsoft.AspNetCore.Hosting
             var metricsEndpointHostingOptions = new MetricsEndpointsHostingOptions();
             setupHostingConfiguration(metricsEndpointHostingOptions);
 
-            var ports = new List<int>();
-
             if (metricsEndpointHostingOptions.AllEndpointsPort.HasValue)
             {
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsEndpoint} on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsTextEndpoint} endpoint on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.EnvironmentInfoEndpoint} endpoint on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
-
-                ports.Add(metricsEndpointHostingOptions.AllEndpointsPort.Value);
             }
             else
             {
                 if (metricsEndpointHostingOptions.MetricsEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsEndpoint} on port {metricsEndpointHostingOptions.MetricsEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.MetricsEndpointPort.Value);
                 }
 
                 if (metricsEndpointHostingOptions.MetricsTextEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsTextEndpoint} endpoint on port {metricsEndpointHostingOptions.MetricsTextEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.MetricsTextEndpointPort.Value);
                 }
 
                 if (metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.EnvironmentInfoEndpoint} endpoint on port {metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.Value);
                 }
-            }
-
-            if (ports.Any())
-            {
-                throw new NotImplementedException("To implement setting custom ports for netcore3.0, removed for now in App.Metrics 4.0.0");
-                // var existingUrl = hostBuilder.GetSetting(WebHostDefaults.ServerUrlsKey);
-                // var additionalUrls = string.Join(";", ports.Distinct().Select(p => $"http://*:{p}/"));
-                // hostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, $"{existingUrl};{additionalUrls}");
             }
 
             hostBuilder.ConfigureServices((context, services) => services.Configure(setupHostingConfiguration));

--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointWebHostBuilderExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Endpoints/Builder/MetricsAspNetEndpointWebHostBuilderExtensions.cs
@@ -3,8 +3,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using App.Metrics.AspNetCore.Endpoints;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -128,43 +126,29 @@ namespace Microsoft.AspNetCore.Hosting
             var metricsEndpointHostingOptions = new MetricsEndpointsHostingOptions();
             setupHostingConfiguration(metricsEndpointHostingOptions);
 
-            var ports = new List<int>();
 
             if (metricsEndpointHostingOptions.AllEndpointsPort.HasValue)
             {
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsEndpoint} on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsTextEndpoint} endpoint on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
                 Console.WriteLine($"Hosting {metricsEndpointHostingOptions.EnvironmentInfoEndpoint} endpoint on port {metricsEndpointHostingOptions.AllEndpointsPort.Value}");
-
-                ports.Add(metricsEndpointHostingOptions.AllEndpointsPort.Value);
             }
             else
             {
                 if (metricsEndpointHostingOptions.MetricsEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsEndpoint} on port {metricsEndpointHostingOptions.MetricsEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.MetricsEndpointPort.Value);
                 }
 
                 if (metricsEndpointHostingOptions.MetricsTextEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.MetricsTextEndpoint} endpoint on port {metricsEndpointHostingOptions.MetricsTextEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.MetricsTextEndpointPort.Value);
                 }
 
                 if (metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.HasValue)
                 {
                     Console.WriteLine($"Hosting {metricsEndpointHostingOptions.EnvironmentInfoEndpoint} endpoint on port {metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.Value}");
-                    ports.Add(metricsEndpointHostingOptions.EnvironmentInfoEndpointPort.Value);
                 }
-            }
-
-            if (ports.Any())
-            {
-                throw new NotImplementedException("To implement setting custom ports for netcore3.0, removed for now in App.Metrics 4.0.0");
-                // var existingUrl = hostBuilder.GetSetting(WebHostDefaults.ServerUrlsKey);
-                // var additionalUrls = string.Join(";", ports.Distinct().Select(p => $"http://*:{p}/"));
-                // hostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, $"{existingUrl};{additionalUrls}");
             }
 
             hostBuilder.ConfigureServices((context, services) => services.Configure(setupHostingConfiguration));


### PR DESCRIPTION
This PR allows for serving the metrics to a custom port, but removes the automatic configuration of the host as described in #497 

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits