### PR TITLE
Fix netstandard2.0 project references

### DIFF
--- a/src/Extensions/src/App.Metrics.AppNetCore/App.Metrics.AppNetCore.csproj
+++ b/src/Extensions/src/App.Metrics.AppNetCore/App.Metrics.AppNetCore.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>App Metrics is an open-source .NET Standard library used to record application metrics.</Description>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <RootNamespace>App.Metrics.AppNetCore</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageTags>appmetrics;metrics</PackageTags>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="App.Metrics" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Extensions/src/App.Metrics.Extensions.Hosting/App.Metrics.Extensions.Hosting.csproj
+++ b/src/Extensions/src/App.Metrics.Extensions.Hosting/App.Metrics.Extensions.Hosting.csproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Microsoft.Extensions.Hosting (IHostBuilder) support for App Metrics.</Description>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <RootNamespace>App.Metrics.Extensions.Hosting</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageTags>appmetrics;metrics;hosting</PackageTags>
     </PropertyGroup>
+   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="App.Metrics.Core" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
As discussed in #611 this PR fixes the issue with the hosting project. I noticed that App.Metrics.AppNetCore also has the same issue, so fixed that while I was at it.

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits