### PR TITLE
Fixed system usage stats not being updated

### DIFF
--- a/src/Extensions/src/App.Metrics.Extensions.Collectors/HostedServices/SystemUsageCollectorHostedService.cs
+++ b/src/Extensions/src/App.Metrics.Extensions.Collectors/HostedServices/SystemUsageCollectorHostedService.cs
@@ -42,6 +42,8 @@ namespace App.Metrics.Extensions.Collectors.HostedServices
 
         private void CollectData(object state)
         {
+            _process.Refresh();
+            
             var totalCpuTimeUsed = _process.TotalProcessorTime.TotalMilliseconds - _lastTotalProcessorTime.TotalMilliseconds;
             var privilegedCpuTimeUsed = _process.PrivilegedProcessorTime.TotalMilliseconds - _lastPrivilegedProcessorTime.TotalMilliseconds;
             var userCpuTimeUsed = _process.UserProcessorTime.TotalMilliseconds - _lastUserProcessorTime.TotalMilliseconds;


### PR DESCRIPTION
### The issue or feature being addressed

Fixed #639 

### Details on the issue fix or feature implementation

Added the _process.Refresh(); call to refresh the stats of the process before it's being set,

### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
