### PR TITLE
moved StatsDBuilder into main StatsD namespace

### DIFF
--- a/src/Reporting/sandbox/MetricsStatsDSandbox/Host.cs
+++ b/src/Reporting/sandbox/MetricsStatsDSandbox/Host.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using App.Metrics;
 using App.Metrics.Reporting;
-using App.Metrics.Reporting.StatsD.Builder;
+using App.Metrics.Reporting.StatsD;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 

--- a/src/Reporting/sandbox/MetricsStatsDSandboxMvc/Program.cs
+++ b/src/Reporting/sandbox/MetricsStatsDSandboxMvc/Program.cs
@@ -7,7 +7,6 @@ using App.Metrics;
 using App.Metrics.AspNetCore;
 using App.Metrics.Extensions.Configuration;
 using App.Metrics.Reporting.StatsD;
-using App.Metrics.Reporting.StatsD.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
@@ -6,7 +6,7 @@ using System;
 using App.Metrics.Builder;
 using App.Metrics.Formatting.StatsD;
 
-namespace App.Metrics.Reporting.StatsD.Builder
+namespace App.Metrics.Reporting.StatsD
 {
     public static class StatsDReporterBuilder
     {


### PR DESCRIPTION
In order to make the StatsD reporter consistent with other App.Metrics reporters, move the reporter into the default App.Metrics.Reporting.SttasD interface.
