### PR TITLE
expose MetricsReportingSocketOptions.FlushInterval inside MetricsReportingStatsDOptions

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace App.Metrics.Formatters
+{
+    public interface IMetricsChunkedOutputFormatter : IMetricsOutputFormatter
+    {
+        /// <summary>
+        ///     Writes the specified <see cref="MetricsDataValueSource" /> to the given stream, streaming one
+        /// data point at a time.
+        /// </summary>
+        /// <param name="metricsData">The <see cref="MetricsDataValueSource" /> being written.</param>
+        /// <param name="maximumChunkSize">Hint for the formatter about the maximum packet size the transport layer can handle</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous write operation.</returns>
+        Task<List<string>> WriteAsync(
+            MetricsDataValueSource metricsData,
+            int maximumChunkSize,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,6 +42,8 @@
     <PackageReference Update="App.Metrics.Formatters.Prometheus" Version="$(AppMetricsVersion)" />
     <PackageReference Update="App.Metrics.Formatters.Graphite" Version="$(AppMetricsVersion)" />
     <PackageReference Update="App.Metrics.Reporting.Graphite" Version="$(AppMetricsVersion)" />
+    <PackageReference Update="App.Metrics.Formatting.StatsD" Version="$(AppMetricsVersion)" />
+    <PackageReference Update="App.Metrics.Reporting.StatsD" Version="$(AppMetricsVersion)" />
 
     <!-- AspNetCore -->
     <PackageReference Update="App.Metrics.AspNetCore" Version="$(AppMetricsVersion)" />
@@ -74,6 +76,7 @@
 	<PackageReference Update="App.Metrics.Graphite" Version="$(AppMetricsVersion)" />
 	<PackageReference Update="App.Metrics.InfluxDB" Version="$(AppMetricsVersion)" />
 	<PackageReference Update="App.Metrics.Prometheus" Version="$(AppMetricsVersion)" />
+    <PackageReference Update="App.Metrics.StatsD" Version="$(AppMetricsVersion)" />
 
     <!-- Tests -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.3.0" />

--- a/src/MetaPackages/MetaPackages.sln
+++ b/src/MetaPackages/MetaPackages.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.InfluxDB", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.Prometheus", "src\App.Metrics.Prometheus\App.Metrics.Prometheus.csproj", "{AE2392F6-9B08-4E0C-A0BB-9E7BF9EE2148}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.StatsD", "src\App.Metrics.StatsD\App.Metrics.StatsD.csproj", "{4F75A543-14D8-473D-B214-9E8B06C813D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,7 @@ Global
 		{94F9F73B-6BCC-4A6C-91BD-CBBF7B321A17} = {2D805782-756E-4C98-B22E-F502BEE95318}
 		{4D6E9C54-253A-44C2-9CAC-3EDB3E76567A} = {2D805782-756E-4C98-B22E-F502BEE95318}
 		{AE2392F6-9B08-4E0C-A0BB-9E7BF9EE2148} = {2D805782-756E-4C98-B22E-F502BEE95318}
+		{4F75A543-14D8-473D-B214-9E8B06C813D6} = {2D805782-756E-4C98-B22E-F502BEE95318}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8699A1D-0BA1-403C-86E9-C789CD2645EB}
@@ -79,5 +82,9 @@ Global
 		{AE2392F6-9B08-4E0C-A0BB-9E7BF9EE2148}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AE2392F6-9B08-4E0C-A0BB-9E7BF9EE2148}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AE2392F6-9B08-4E0C-A0BB-9E7BF9EE2148}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F75A543-14D8-473D-B214-9E8B06C813D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F75A543-14D8-473D-B214-9E8B06C813D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F75A543-14D8-473D-B214-9E8B06C813D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F75A543-14D8-473D-B214-9E8B06C813D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/MetaPackages/src/App.Metrics.StatsD/App.Metrics.StatsD.csproj
+++ b/src/MetaPackages/src/App.Metrics.StatsD/App.Metrics.StatsD.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>App Metrics StatsD Metapackage</Description>
+    <AssemblyTitle>App.Metrics.StatsD</AssemblyTitle>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageTags>appmetrics;statsd</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="App.Metrics.Formatting.StatsD" />
+    <PackageReference Include="App.Metrics.Reporting.StatsD" />
+  </ItemGroup>
+
+</Project>

--- a/src/Reporting/sandbox/MetricsStatsDSandbox/Host.cs
+++ b/src/Reporting/sandbox/MetricsStatsDSandbox/Host.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using App.Metrics;
 using App.Metrics.Reporting;
-using App.Metrics.Reporting.StatsD.Builder;
+using App.Metrics.Reporting.StatsD;
 using Microsoft.Extensions.Configuration;
 using Serilog;
 

--- a/src/Reporting/sandbox/MetricsStatsDSandboxMvc/Program.cs
+++ b/src/Reporting/sandbox/MetricsStatsDSandboxMvc/Program.cs
@@ -7,7 +7,6 @@ using App.Metrics;
 using App.Metrics.AspNetCore;
 using App.Metrics.Extensions.Configuration;
 using App.Metrics.Reporting.StatsD;
-using App.Metrics.Reporting.StatsD.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
@@ -21,12 +21,12 @@ namespace App.Metrics.Formatting.StatsD.Internal
                                                                   StatsDFormatterConstants.ItemTagName
                                                               };
 
-        private readonly MetricsStatsDOptions _options;
         private readonly ConcurrentDictionary<string, StatsDSampler> _samplers = new ConcurrentDictionary<string, StatsDSampler>();
 
-        public StatsDPointSampler(MetricsStatsDOptions options) { _options = options; }
+        public StatsDPointSampler(MetricsStatsDOptions options) { Options = options; }
 
         public ConcurrentQueue<StatsDPoint> Points { get; } = new ConcurrentQueue<StatsDPoint>();
+        public MetricsStatsDOptions Options { get; }
 
         public void Add(
             string context,
@@ -67,7 +67,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
             tagsDictionary.TryGetValue(StatsDFormatterConstants.SampleRateTagName, out var tagSampleRateStr);
             if (!double.TryParse(tagSampleRateStr, out var tagSampleRate))
             {
-                tagSampleRate = _options.DefaultSampleRate;
+                tagSampleRate = Options.DefaultSampleRate;
             }
 
             var sampler = _samplers.GetOrAdd(key, _ => new StatsDSampler());
@@ -163,7 +163,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
             var result = new List<string>();
             while (Points.TryDequeue(out var point))
             {
-                result.Add(point.Write(_options));
+                result.Add(point.Write(Options));
             }
 
 #if NETSTANDARD2_0

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/Client/DefaultSocketClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/Client/DefaultSocketClient.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using App.Metrics.Logging;
@@ -17,6 +18,7 @@ namespace App.Metrics.Reporting.Socket.Client
         private static long _failureAttempts;
         private readonly SocketClient _socketClient;
         private readonly SocketPolicy _socketPolicy;
+        private readonly MetricsReportingSocketOptions _options;
 
         public string Endpoint
         {
@@ -25,9 +27,11 @@ namespace App.Metrics.Reporting.Socket.Client
                 return _socketClient.Endpoint;
             }
         }
+        public bool PreferChunkedOutput => _options.SocketSettings.ProtocolType == ProtocolType.Udp;
 
         public DefaultSocketClient(MetricsReportingSocketOptions options)
         {
+            _options = options;
             _socketClient = CreateSocketClient(options.SocketSettings);
             _socketPolicy = options.SocketPolicy;
             _failureAttempts = 0;

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/Client/SocketSettings.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/Client/SocketSettings.cs
@@ -44,6 +44,14 @@ namespace App.Metrics.Reporting.Socket.Client
         /// </value>
         public int Port { get; set; }
 
+        /// <summary>
+        ///     Gets or sets the maximum packet size for UDP datagrams
+        /// </summary>
+        /// <value>
+        ///     Packet size, in bytes
+        /// </value>
+        public int MaxUdpDatagramSize { get; set; } = 4 * 1024; // Defaults to 4 Kib
+
         public string Endpoint
         {
             get

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/App.Metrics.Reporting.StatsD.csproj
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/App.Metrics.Reporting.StatsD.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="App.Metrics.Reporting.Socket" />
+    <PackageReference Include="App.Metrics.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\App.Metrics.Formatting.StatsD\App.Metrics.Formatting.StatsD.csproj" />
+    <ProjectReference Include="..\App.Metrics.Reporting.Socket\App.Metrics.Reporting.Socket.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/MetricsReportingStatsDOptions.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/MetricsReportingStatsDOptions.cs
@@ -5,6 +5,7 @@
 using App.Metrics.Filters;
 using App.Metrics.Formatting.StatsD;
 using App.Metrics.Reporting.Socket.Client;
+using System;
 
 namespace App.Metrics.Reporting.StatsD
 {
@@ -32,6 +33,11 @@ namespace App.Metrics.Reporting.StatsD
         ///     The Socket policy.
         /// </value>
         public SocketPolicy SocketPolicy { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the interval between flushing metrics.
+        /// </summary>
+        public TimeSpan FlushInterval { get; set; }
 
         /// <summary>
         ///     Gets or sets the Socket client related settings.

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
@@ -6,7 +6,7 @@ using System;
 using App.Metrics.Builder;
 using App.Metrics.Formatting.StatsD;
 
-namespace App.Metrics.Reporting.StatsD.Builder
+namespace App.Metrics.Reporting.StatsD
 {
     public static class StatsDReporterBuilder
     {

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
@@ -35,7 +35,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -70,7 +70,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -102,7 +102,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -137,7 +137,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;


### PR DESCRIPTION
make it possible for the `MetricsReportingStatsDOptions` to specify the `TimeSpan FlushInterval` that the underlying socket reporter will use for writing out to its destination, rather than hard-coding it to `TimeSpan.Zero`