### PR TITLE
Add chunked output for formatters for UDP datagram output

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace App.Metrics.Formatters
+{
+    public interface IMetricsChunkedOutputFormatter : IMetricsOutputFormatter
+    {
+        /// <summary>
+        ///     Writes the specified <see cref="MetricsDataValueSource" /> to the given stream, streaming one
+        /// data point at a time.
+        /// </summary>
+        /// <param name="metricsData">The <see cref="MetricsDataValueSource" /> being written.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous write operation.</returns>
+        Task<List<string>> WriteAsync(
+            MetricsDataValueSource metricsData,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Formatters/IMetricsChunkedOutputFormatter.cs
@@ -11,10 +11,12 @@ namespace App.Metrics.Formatters
         /// data point at a time.
         /// </summary>
         /// <param name="metricsData">The <see cref="MetricsDataValueSource" /> being written.</param>
+        /// <param name="maximumChunkSize">Hint for the formatter about the maximum packet size the transport layer can handle</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /></param>
         /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous write operation.</returns>
         Task<List<string>> WriteAsync(
             MetricsDataValueSource metricsData,
+            int maximumChunkSize,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
@@ -21,12 +21,12 @@ namespace App.Metrics.Formatting.StatsD.Internal
                                                                   StatsDFormatterConstants.ItemTagName
                                                               };
 
-        private readonly MetricsStatsDOptions _options;
         private readonly ConcurrentDictionary<string, StatsDSampler> _samplers = new ConcurrentDictionary<string, StatsDSampler>();
 
-        public StatsDPointSampler(MetricsStatsDOptions options) { _options = options; }
+        public StatsDPointSampler(MetricsStatsDOptions options) { Options = options; }
 
         public ConcurrentQueue<StatsDPoint> Points { get; } = new ConcurrentQueue<StatsDPoint>();
+        public MetricsStatsDOptions Options { get; }
 
         public void Add(
             string context,
@@ -67,7 +67,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
             tagsDictionary.TryGetValue(StatsDFormatterConstants.SampleRateTagName, out var tagSampleRateStr);
             if (!double.TryParse(tagSampleRateStr, out var tagSampleRate))
             {
-                tagSampleRate = _options.DefaultSampleRate;
+                tagSampleRate = Options.DefaultSampleRate;
             }
 
             var sampler = _samplers.GetOrAdd(key, _ => new StatsDSampler());
@@ -163,7 +163,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
             var result = new List<string>();
             while (Points.TryDequeue(out var point))
             {
-                result.Add(point.Write(_options));
+                result.Add(point.Write(Options));
             }
 
 #if NETSTANDARD2_0

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/MetricsStatsDStringOutputFormatter.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/MetricsStatsDStringOutputFormatter.cs
@@ -18,6 +18,8 @@ namespace App.Metrics.Formatting.StatsD
     {
         private readonly MetricsStatsDOptions _options;
         private readonly StatsDPointSampler _samplers;
+        private readonly MetricSnapshotStatsDStringWriter _nullWriter;
+        private readonly MetricSnapshotSerializer _serializer;
 
         public MetricsStatsDStringOutputFormatter() 
             : this(new MetricsStatsDOptions(), null)
@@ -41,6 +43,8 @@ namespace App.Metrics.Formatting.StatsD
             _options = options ?? throw new ArgumentNullException(nameof(options));
             MetricFields = metricFields ?? new MetricFields();
             _samplers = new StatsDPointSampler(_options);
+            _nullWriter = new MetricSnapshotStatsDStringWriter(null, _samplers, _options);
+            _serializer = new MetricSnapshotSerializer();
         }
 
         /// <inheritdoc />
@@ -60,21 +64,46 @@ namespace App.Metrics.Formatting.StatsD
                 throw new ArgumentNullException(nameof(output));
             }
 
-            var serializer = new MetricSnapshotSerializer();
-
             await using var writer = new MetricSnapshotStatsDStringWriter(output, _samplers, _options);
-            serializer.Serialize(writer, metricsData, MetricFields);
+            _serializer.Serialize(writer, metricsData, MetricFields);
         }
 
-        public Task<List<string>> WriteAsync(MetricsDataValueSource metricsData, CancellationToken cancellationToken = default)
+        public Task<List<string>> WriteAsync(
+            MetricsDataValueSource metricsData, 
+            int maxChunkSize,
+            CancellationToken cancellationToken = default)
         {
-            var writer = new MetricSnapshotStatsDStringWriter(null, _samplers, _options);
-            var serializer = new MetricSnapshotSerializer();
-            serializer.Serialize(writer, metricsData, MetricFields);
+            _serializer.Serialize(_nullWriter, metricsData, MetricFields);
 
-            var result = writer.Sampler.Points
-                .Select(point => point.Write(writer.Sampler.Options))
-                .ToList();
+            var chunks = new List<string>();
+            while (_samplers.Points.TryDequeue(out var point))
+            {
+                chunks.Add(point.Write(_samplers.Options));
+            }
+
+            // Shortcut, no need to calculate batch for empty or single result.
+            if (chunks.Count < 2)
+            {
+                return Task.FromResult(chunks);
+            }
+
+            var result = new List<string>();
+            var a = chunks[0];
+            for (var i = 1; i < chunks.Count; i++)
+            {
+                var b = chunks[i];
+                var joined = $"{a}\n{b}";
+                if (joined.Length > maxChunkSize)
+                {
+                    result.Add(a);
+                    a = b;
+                }
+                else
+                {
+                    a = joined;
+                }
+            }
+            result.Add(a);
 
             return Task.FromResult(result);
         }

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/Client/DefaultSocketClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/Client/DefaultSocketClient.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using App.Metrics.Logging;
@@ -17,6 +18,7 @@ namespace App.Metrics.Reporting.Socket.Client
         private static long _failureAttempts;
         private readonly SocketClient _socketClient;
         private readonly SocketPolicy _socketPolicy;
+        private readonly MetricsReportingSocketOptions _options;
 
         public string Endpoint
         {
@@ -25,9 +27,11 @@ namespace App.Metrics.Reporting.Socket.Client
                 return _socketClient.Endpoint;
             }
         }
+        public bool PreferChunkedOutput => _options.SocketSettings.ProtocolType == ProtocolType.Udp;
 
         public DefaultSocketClient(MetricsReportingSocketOptions options)
         {
+            _options = options;
             _socketClient = CreateSocketClient(options.SocketSettings);
             _socketPolicy = options.SocketPolicy;
             _failureAttempts = 0;

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/Client/SocketSettings.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/Client/SocketSettings.cs
@@ -44,6 +44,14 @@ namespace App.Metrics.Reporting.Socket.Client
         /// </value>
         public int Port { get; set; }
 
+        /// <summary>
+        ///     Gets or sets the maximum packet size for UDP datagrams
+        /// </summary>
+        /// <value>
+        ///     Packet size, in bytes
+        /// </value>
+        public int MaxUdpDatagramSize { get; set; } = 4 * 1024; // Defaults to 4 Kib
+
         public string Endpoint
         {
             get

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
@@ -80,18 +80,21 @@ namespace App.Metrics.Reporting.Socket
                 _options.SocketSettings.MaxUdpDatagramSize,
                 cancellationToken);
 
+            var success = true;
             foreach (var chunk in chunks)
             {
                 var result = await _socketClient.WriteAsync(chunk, cancellationToken);
                 if (!result.Success)
                 {
                     Logger.Error(result.ErrorMessage);
-                    return false;
+                    success = false;
                 }
             }
 
-            Logger.Trace("Successfully flushed chunked metrics snapshot");
-            return true;
+            Logger.Trace(success 
+                ? "Successfully flushed chunked metrics snapshot"
+                : "Flushed chunked metrics snapshot with error(s)");
+            return success;
         }
 
         private async Task<bool> WriteOutput(MetricsDataValueSource metricsData, CancellationToken cancellationToken = default)

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
@@ -18,6 +18,7 @@ namespace App.Metrics.Reporting.Socket
     {
         private static readonly ILog Logger = LogProvider.For<SocketMetricsReporter>();
         private readonly DefaultSocketClient _socketClient;
+        private readonly MetricsReportingSocketOptions _options;
 
         public SocketMetricsReporter(MetricsReportingSocketOptions options)
         {
@@ -30,6 +31,7 @@ namespace App.Metrics.Reporting.Socket
             {
                 throw new ArgumentNullException(nameof(options.MetricsOutputFormatter));
             }
+            _options = options ?? throw new ArgumentNullException(nameof(options));
 
             if (options.FlushInterval < TimeSpan.Zero)
             {
@@ -61,26 +63,52 @@ namespace App.Metrics.Reporting.Socket
         /// <inheritdoc />
         public async Task<bool> FlushAsync(MetricsDataValueSource metricsData, CancellationToken cancellationToken = default)
         {
+            if (_socketClient.PreferChunkedOutput && Formatter is IMetricsChunkedOutputFormatter formatter)
+                return await WriteChunkedOutput(formatter, metricsData, cancellationToken);
+            return await WriteOutput(metricsData, cancellationToken);
+        }
+
+        private async Task<bool> WriteChunkedOutput(
+            IMetricsChunkedOutputFormatter formatter,
+            MetricsDataValueSource metricsData,
+            CancellationToken cancellationToken = default)
+        {
+            Logger.Trace("Flushing chunked metrics snapshot");
+
+            var chunks = await formatter.WriteAsync(metricsData, cancellationToken);
+            foreach (var chunk in chunks)
+            {
+                var result = await _socketClient.WriteAsync(chunk, cancellationToken);
+                if (!result.Success)
+                {
+                    Logger.Error(result.ErrorMessage);
+                    return false;
+                }
+            }
+
+            Logger.Trace("Successfully flushed chunked metrics snapshot");
+            return true;
+        }
+
+        private async Task<bool> WriteOutput(MetricsDataValueSource metricsData, CancellationToken cancellationToken = default)
+        {
             Logger.Trace("Flushing metrics snapshot");
 
-            using (var stream = new MemoryStream())
+            using var stream = new MemoryStream();
+
+            await Formatter.WriteAsync(stream, metricsData, cancellationToken);
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            var result = await _socketClient.WriteAsync(output, cancellationToken);
+
+            if (result.Success)
             {
-                await Formatter.WriteAsync(stream, metricsData, cancellationToken);
-
-                var output = Encoding.UTF8.GetString(stream.ToArray());
-
-                var result = await _socketClient.WriteAsync(output, cancellationToken);
-
-                if (result.Success)
-                {
-                    Logger.Trace("Successfully flushed metrics snapshot");
-                    return true;
-                }
-
-                Logger.Error(result.ErrorMessage);
-
-                return false;
+                Logger.Trace("Successfully flushed metrics snapshot");
+                return true;
             }
+
+            Logger.Error(result.ErrorMessage);
+
+            return false;
         }
     }
 }

--- a/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.Socket/SocketMetricsReporter.cs
@@ -75,7 +75,11 @@ namespace App.Metrics.Reporting.Socket
         {
             Logger.Trace("Flushing chunked metrics snapshot");
 
-            var chunks = await formatter.WriteAsync(metricsData, cancellationToken);
+            var chunks = await formatter.WriteAsync(
+                metricsData, 
+                _options.SocketSettings.MaxUdpDatagramSize,
+                cancellationToken);
+
             foreach (var chunk in chunks)
             {
                 var result = await _socketClient.WriteAsync(chunk, cancellationToken);


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- #650

### Details on the issue fix or feature implementation

- Add a way for formatters to return pieces of serialized packets of metrics data instead of a single write to the stream. This can be used to split the data sent to the aggregator server by the transport layer.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included the github issue number in my commits
