### PR TITLE
expose MetricsReportingSocketOptions.FlushInterval inside MetricsRepo…

### DIFF
--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/MetricsReportingStatsDOptions.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/MetricsReportingStatsDOptions.cs
@@ -5,6 +5,7 @@
 using App.Metrics.Filters;
 using App.Metrics.Formatting.StatsD;
 using App.Metrics.Reporting.Socket.Client;
+using System;
 
 namespace App.Metrics.Reporting.StatsD
 {
@@ -32,6 +33,11 @@ namespace App.Metrics.Reporting.StatsD
         ///     The Socket policy.
         /// </value>
         public SocketPolicy SocketPolicy { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the interval between flushing metrics.
+        /// </summary>
+        public TimeSpan FlushInterval { get; set; }
 
         /// <summary>
         ///     Gets or sets the Socket client related settings.

--- a/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.StatsD/StatsDReporterBuilder.cs
@@ -35,7 +35,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -70,7 +70,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -102,7 +102,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;
@@ -137,7 +137,7 @@ namespace App.Metrics.Reporting.StatsD
                 opt =>
                 {
                     opt.MetricsOutputFormatter = formatter;
-                    opt.FlushInterval = TimeSpan.Zero;
+                    opt.FlushInterval = options.FlushInterval;
                     opt.SocketSettings = options.SocketSettings;
                     opt.SocketPolicy = options.SocketPolicy;
                     opt.Filter = options.Filter;


### PR DESCRIPTION
make it possible for the `MetricsReportingStatsDOptions` to specify the `TimeSpan FlushInterval` that the underlying socket reporter will use for writing out to its destination, rather than hard-coding it to `TimeSpan.Zero`

replaces https://github.com/AppMetrics/AppMetrics/pull/654