### PR TITLE
Stop and flush on host shutdown

### DIFF
--- a/src/Extensions/src/App.Metrics.Extensions.Hosting/ServiceCollectionMetricsReportingExtensions.cs
+++ b/src/Extensions/src/App.Metrics.Extensions.Hosting/ServiceCollectionMetricsReportingExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
 using App.Metrics;
 using App.Metrics.Extensions.Hosting;
 using App.Metrics.Reporting;
@@ -25,9 +26,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var options = serviceProvider.GetRequiredService<MetricsOptions>();
                 var metrics = serviceProvider.GetRequiredService<IMetrics>();
                 var reporters = serviceProvider.GetService<IReadOnlyCollection<IReportMetrics>>();
-
-                var instance = new MetricsReporterBackgroundService(metrics, options, reporters);
-
+                var lifetime = serviceProvider.GetService<IHostApplicationLifetime>();
+                var instance = new MetricsReporterBackgroundService(metrics, options, reporters, lifetime);
                 if (unobservedTaskExceptionHandler != null)
                 {
                     instance.UnobservedTaskException += unobservedTaskExceptionHandler;


### PR DESCRIPTION
### The issue or feature being addressed

#659

### Details on the issue fix or feature implementation

I have a CronJob which may start and stop very quickly. Some metrics are generated but as a result of how short lived the application is, the metrics are never sent. After debugging the issue I have concluded that the reason for this is because the reporter is running as a background worker which is essentially cancelled before it can even start. Furthermore due to the way the hosted application works, the TaskFactory never completes once the application is shutting down.

This change uses the `IHostApplicationLifetime` service to detect the `ApplicationStopping` signal and flushes the remaining metrics one last time before the application is fully stopped.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-buil)
- [ ] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits

**_Notes:_**

* The build was broken already on a vanilla checkout but the project I edited was building and continues to build fine.
* I did not see existing unit tests for this function or area of code, I'm not sure how to proceed with a unit test.
