### PR TITLE
#665 Correcting link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can find the benchmark results [here](https://github.com/alhardy/AppMetrics/
 
 ## Contributing
 
-See the [contribution guidlines](CONTRIBUTING.md) for details.
+See the [contribution guidlines](.github/CONTRIBUTING.md) for details.
 
 ## Acknowledgements
 


### PR DESCRIPTION
The current link from the README page returns a 404 not found page on Github. Hopefully this correct that.

### The issue or feature being addressed

- [Issue #665](https://github.com/AppMetrics/AppMetrics/issues/665)

### Details on the issue fix or feature implementation

- Just updating the link to reference the CONTRIBUTING.md file in .github directory


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
