### PR TITLE
Convert AppMetrics Meter to StatsD Count

### DIFF
--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
@@ -58,7 +58,8 @@ namespace App.Metrics.Formatting.StatsD.Internal
             var statsDMetricType = StatsDSyntax.FormatMetricType(metricType);
             if (metricType == AppMetricsConstants.Pack.ApdexMetricTypeValue && field != "score")
                 statsDMetricType = StatsDSyntax.Count;
-            if (!StatsDSyntax.CanBeSampled(statsDMetricType))
+
+            if (!StatsDSyntax.CanBeSampled(statsDMetricType) || metricType == AppMetricsConstants.Pack.MeterMetricTypeValue)
             {
                 Points.Enqueue(new StatsDPoint(key, value, statsDMetricType, null, tags, serializer, timestamp));
                 return;

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDSyntax.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDSyntax.cs
@@ -13,8 +13,11 @@ namespace App.Metrics.Formatting.StatsD.Internal
         public static readonly string Count = "c";
         public static readonly string Gauge = "g";
         public static readonly string Histogram = "h";
-        public static readonly string Meter = "m";
         public static readonly string Timer = "ms";
+        // Bug: DogStatsD does not understand meter metrics
+        // Bug: StatsD removed meter metrics from their supported metrics type
+        // Fix: Convert meter metrics to count
+        // public static readonly string Meter = "m";
 
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(StatsDSyntax));
         private static readonly DateTime Origin = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -42,7 +45,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
                 { AppMetricsConstants.Pack.GaugeMetricTypeValue, Gauge },
                 { AppMetricsConstants.Pack.CounterMetricTypeValue, Count },
                 { AppMetricsConstants.Pack.HistogramMetricTypeValue, Histogram },
-                { AppMetricsConstants.Pack.MeterMetricTypeValue, Meter },
+                { AppMetricsConstants.Pack.MeterMetricTypeValue, Count },
                 { AppMetricsConstants.Pack.TimerMetricTypeValue, Timer }
             };
 

--- a/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
@@ -595,6 +595,48 @@ namespace App.Metrics.Reporting.StatsD.Facts
             }
         }
 
+        [Fact]
+        public async Task Meters_should_not_be_sampled()
+        {
+            // Arrange
+            var sources = new List<MetricsDataValueSource>();
+            var timeStamp = _timestamp;
+
+            var expected =
+                "test.test_meter.meter.value:4|c|#unit:none,unit_rate:ms,timestamp:1483232461";
+
+            // Act
+            for (var i = 0; i < 100; ++i)
+            {
+                sources.Add(CreateMetricsDataValueSource(ref timeStamp));
+            }
+            var emittedData = (await Serialize(sources, 0.5)).Split('\n');
+
+            // Assert
+            emittedData.Length.Should().Be(100);
+            emittedData[0].Should().Be(expected);
+
+            MetricsDataValueSource CreateMetricsDataValueSource(ref DateTime timestamp)
+            {
+                var clock = new TestClock();
+                var meter = new DefaultMeterMetric(clock);
+                meter.Mark(1);
+                meter.Mark(1);
+                meter.Mark(1);
+                meter.Mark(1);
+                var meterValueSource = new MeterValueSource(
+                    "test meter",
+                    ConstantValue.Provider(meter.Value),
+                    Unit.None,
+                    TimeUnit.Milliseconds,
+                    MetricTags.Empty);
+                var valueSource = CreateValueSource("test", meters: meterValueSource);
+                var result = new MetricsDataValueSource(timestamp, new[] { valueSource });
+                timestamp += TimeSpan.FromSeconds(1);
+                return result;
+            }
+        }
+
         private async Task<string> Serialize(
             IEnumerable<MetricsDataValueSource> dataValueSource,
             double sampleRate = 1.0)

--- a/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
@@ -380,7 +380,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter.meter.value:1|m|#unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter.meter.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -403,7 +403,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter.meter.value:1|m|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter.meter.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -426,9 +426,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|m|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|m|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter.meter.value:2|m|#unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter__items.meter.item1:value1.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
+                "test.test_meter.meter.value:2|c|#unit:none,unit_rate:ms,timestamp:1483232461";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);
@@ -452,9 +452,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|m|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|m|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter.meter.value:2|m|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter__items.meter.item1:value1.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
+                "test.test_meter.meter.value:2|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);

--- a/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotStatsDStringSerializerTest.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotStatsDStringSerializerTest.cs
@@ -378,7 +378,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter.meter.value:1|m";
+                "test.test_meter.meter.value:1|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -400,7 +400,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         public async Task Can_report_meters_when_multidimensional()
         {
             // Arrange
-            var expected = "test.test_meter.meter.value:1|m";
+            var expected = "test.test_meter.meter.value:1|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -423,9 +423,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|m\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|m\n" +
-                "test.test_meter.meter.value:2|m";
+                "test.test_meter__items.meter.item1:value1.value:1|c\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c\n" +
+                "test.test_meter.meter.value:2|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);
@@ -449,9 +449,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|m\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|m\n" +
-                "test.test_meter.meter.value:2|m";
+                "test.test_meter__items.meter.item1:value1.value:1|c\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c\n" +
+                "test.test_meter.meter.value:2|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- #668

### Details on the issue fix or feature implementation

- We're emulating what DogStatsD is doing by converting `Meter` into the closest metric we have to DataDog `Rate` metric, which is the `Count` metric in AppMetrics and StatsD.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
