### PR TITLE
Statsd/remove timestamp tagging

### DIFF
--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
@@ -27,17 +27,13 @@ namespace App.Metrics.Formatting.StatsD
                 builder.Append(point.SampleRate.Value.ToString("0.###############"));
             }
 
-            var tags = new List<string>();
-
             if (point.Tags != null && point.Tags.Count > 0)
             {
-                tags.AddRange(point.Tags.Select(tag => $"{tag.Key}:{tag.Value}"));
+                builder.Append('|');
+                builder.Append(options.TagMarker);
+                builder.Append(string.Join(",", point.Tags.Select(tag => $"{tag.Key}:{tag.Value}")));
             }
-
-            builder.Append('|');
-            builder.Append(options.TagMarker);
-            builder.Append(string.Join(",", tags));
-
+            
             return builder.ToString();
         }
     }

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
@@ -34,8 +34,6 @@ namespace App.Metrics.Formatting.StatsD
                 tags.AddRange(point.Tags.Select(tag => $"{tag.Key}:{tag.Value}"));
             }
 
-            tags.Add($"{StatsDFormatterConstants.TimestampTagName}:{StatsDSyntax.FormatTimestamp(point.UtcTimestamp)}");
-
             builder.Append('|');
             builder.Append(options.TagMarker);
             builder.Append(string.Join(",", tags));

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDFormatterConstants.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDFormatterConstants.cs
@@ -10,7 +10,6 @@ namespace App.Metrics.Formatting.StatsD.Internal
     {
         public static string ItemTagName = "item";
         public static string SampleRateTagName = "sampleRate";
-        public static string TimestampTagName = "timestamp";
 
         public static class Defaults
         {

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
@@ -17,6 +17,9 @@ namespace App.Metrics.Formatting.StatsD.Internal
         private static readonly HashSet<string> ExcludeTags = new HashSet<string>
                                                               {
                                                                   AppMetricsConstants.Pack.MetricTagsTypeKey,
+                                                                  AppMetricsConstants.Pack.MetricTagsUnitKey,
+                                                                  AppMetricsConstants.Pack.MetricTagsUnitRateKey,
+                                                                  AppMetricsConstants.Pack.MetricTagsUnitRateDurationKey,
                                                                   StatsDFormatterConstants.SampleRateTagName,
                                                                   StatsDFormatterConstants.ItemTagName
                                                               };

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDSyntax.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDSyntax.cs
@@ -69,11 +69,6 @@ namespace App.Metrics.Formatting.StatsD.Internal
             return MetricTypes.TryGetValue(metricType, out var type) ? type : Gauge;
         }
 
-        public static long FormatTimestamp(DateTime? utcTimestamp)
-            => utcTimestamp.HasValue
-                ? (long)utcTimestamp.Value.Subtract(Origin).TotalSeconds
-                : (long)DateTime.UtcNow.Subtract(Origin).TotalSeconds;
-
         /// <summary>
         ///     The numeric value format should depend on the original type. StatsD prefers integers.
         /// </summary>

--- a/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/MetricSnapshotDogStatsDStringSerializerTest.cs
@@ -34,11 +34,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_apdex.apdex.samples:0|c|#unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.score:0|g|#unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.satisfied:0|c|#unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.tolerating:0|c|#unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.frustrating:0|c|#unit:result,timestamp:1483232461";
+                "test.test_apdex.apdex.samples:0|c\n" +
+                "test.test_apdex.apdex.score:0|g\n" +
+                "test.test_apdex.apdex.satisfied:0|c\n" +
+                "test.test_apdex.apdex.tolerating:0|c\n" +
+                "test.test_apdex.apdex.frustrating:0|c";
             var clock = new TestClock();
             var apdex = new DefaultApdexMetric(_defaultReservoir, clock, false);
             var apdexValueSource = new ApdexValueSource(
@@ -58,11 +58,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_apdex.apdex.samples:0|c|#host:server1,env:staging,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.score:0|g|#host:server1,env:staging,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.satisfied:0|c|#host:server1,env:staging,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.tolerating:0|c|#host:server1,env:staging,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.frustrating:0|c|#host:server1,env:staging,unit:result,timestamp:1483232461";
+                "test.test_apdex.apdex.samples:0|c|#host:server1,env:staging\n" +
+                "test.test_apdex.apdex.score:0|g|#host:server1,env:staging\n" +
+                "test.test_apdex.apdex.satisfied:0|c|#host:server1,env:staging\n" +
+                "test.test_apdex.apdex.tolerating:0|c|#host:server1,env:staging\n" +
+                "test.test_apdex.apdex.frustrating:0|c|#host:server1,env:staging";
             var clock = new TestClock();
             var apdex = new DefaultApdexMetric(_defaultReservoir, clock, false);
             var apdexValueSource = new ApdexValueSource(
@@ -82,11 +82,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_apdex.apdex.samples:0|c|#key1:value1,key2:value2,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.score:0|g|#key1:value1,key2:value2,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.satisfied:0|c|#key1:value1,key2:value2,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.tolerating:0|c|#key1:value1,key2:value2,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.frustrating:0|c|#key1:value1,key2:value2,unit:result,timestamp:1483232461";
+                "test.test_apdex.apdex.samples:0|c|#key1:value1,key2:value2\n" +
+                "test.test_apdex.apdex.score:0|g|#key1:value1,key2:value2\n" +
+                "test.test_apdex.apdex.satisfied:0|c|#key1:value1,key2:value2\n" +
+                "test.test_apdex.apdex.tolerating:0|c|#key1:value1,key2:value2\n" +
+                "test.test_apdex.apdex.frustrating:0|c|#key1:value1,key2:value2";
             var clock = new TestClock();
             var apdex = new DefaultApdexMetric(_defaultReservoir, clock, false);
             var apdexValueSource = new ApdexValueSource(
@@ -106,11 +106,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_apdex.apdex.samples:0|c|#host:server1,env:staging,anothertag:thevalue,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.score:0|g|#host:server1,env:staging,anothertag:thevalue,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.satisfied:0|c|#host:server1,env:staging,anothertag:thevalue,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.tolerating:0|c|#host:server1,env:staging,anothertag:thevalue,unit:result,timestamp:1483232461\n" +
-                "test.test_apdex.apdex.frustrating:0|c|#host:server1,env:staging,anothertag:thevalue,unit:result,timestamp:1483232461";
+                "test.test_apdex.apdex.samples:0|c|#host:server1,env:staging,anothertag:thevalue\n" +
+                "test.test_apdex.apdex.score:0|g|#host:server1,env:staging,anothertag:thevalue\n" +
+                "test.test_apdex.apdex.satisfied:0|c|#host:server1,env:staging,anothertag:thevalue\n" +
+                "test.test_apdex.apdex.tolerating:0|c|#host:server1,env:staging,anothertag:thevalue\n" +
+                "test.test_apdex.apdex.frustrating:0|c|#host:server1,env:staging,anothertag:thevalue";
             var clock = new TestClock();
             var apdex = new DefaultApdexMetric(_defaultReservoir, clock, false);
             var apdexValueSource = new ApdexValueSource(
@@ -130,11 +130,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_counter__items.counter.item1:value1.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item1:value1.percent:50|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.percent:50|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter.counter.value:2|c|#unit:none,timestamp:1483232461";
+                "test.test_counter__items.counter.item1:value1.total:1|c\n" +
+                "test.test_counter__items.counter.item1:value1.percent:50|c\n" +
+                "test.test_counter__items.counter.item2:value2.total:1|c\n" +
+                "test.test_counter__items.counter.item2:value2.percent:50|c\n" +
+                "test.test_counter.counter.value:2|c";
             var counter = new DefaultCounterMetric();
             counter.Increment(new MetricSetItem("item1", "value1"), 1);
             counter.Increment(new MetricSetItem("item2", "value2"), 1);
@@ -156,11 +156,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_counter__items.counter.item1:value1.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item1:value1.percent:50|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.percent:50|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter.counter.value:2|c|#unit:none,timestamp:1483232461";
+                "test.test_counter__items.counter.item1:value1.total:1|c\n" +
+                "test.test_counter__items.counter.item1:value1.percent:50|c\n" +
+                "test.test_counter__items.counter.item2:value2.total:1|c\n" +
+                "test.test_counter__items.counter.item2:value2.percent:50|c\n" +
+                "test.test_counter.counter.value:2|c";
             var counter = new DefaultCounterMetric();
             counter.Increment(new MetricSetItem("item1", "value1"), 1);
             counter.Increment(new MetricSetItem("item2", "value2"), 1);
@@ -182,11 +182,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_counter__items.counter.item1:value1.total:1|c|#key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item1:value1.percent:50|c|#key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.total:1|c|#key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.percent:50|c|#key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter.counter.value:2|c|#key1:value1,key2:value2,unit:none,timestamp:1483232461";
+                "test.test_counter__items.counter.item1:value1.total:1|c|#key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item1:value1.percent:50|c|#key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item2:value2.total:1|c|#key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item2:value2.percent:50|c|#key1:value1,key2:value2\n" +
+                "test.test_counter.counter.value:2|c|#key1:value1,key2:value2";
             var counter = new DefaultCounterMetric();
             counter.Increment(new MetricSetItem("item1", "value1"), 1);
             counter.Increment(new MetricSetItem("item2", "value2"), 1);
@@ -208,11 +208,11 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_counter__items.counter.item1:value1.total:1|c|#host:server1,env:staging,key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item1:value1.percent:50|c|#host:server1,env:staging,key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.total:1|c|#host:server1,env:staging,key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.percent:50|c|#host:server1,env:staging,key1:value1,key2:value2,unit:none,timestamp:1483232461\n" +
-                "test.test_counter.counter.value:2|c|#host:server1,env:staging,key1:value1,key2:value2,unit:none,timestamp:1483232461";
+                "test.test_counter__items.counter.item1:value1.total:1|c|#host:server1,env:staging,key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item1:value1.percent:50|c|#host:server1,env:staging,key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item2:value2.total:1|c|#host:server1,env:staging,key1:value1,key2:value2\n" +
+                "test.test_counter__items.counter.item2:value2.percent:50|c|#host:server1,env:staging,key1:value1,key2:value2\n" +
+                "test.test_counter.counter.value:2|c|#host:server1,env:staging,key1:value1,key2:value2";
             var counterTags = new MetricTags(new[] { "key1", "key2" }, new[] { "value1", "value2" });
             var counter = new DefaultCounterMetric();
             counter.Increment(new MetricSetItem("item1", "value1"), 1);
@@ -235,9 +235,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_counter__items.counter.item1:value1.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter__items.counter.item2:value2.total:1|c|#unit:none,timestamp:1483232461\n" +
-                "test.test_counter.counter.value:2|c|#unit:none,timestamp:1483232461";
+                "test.test_counter__items.counter.item1:value1.total:1|c\n" +
+                "test.test_counter__items.counter.item2:value2.total:1|c\n" +
+                "test.test_counter.counter.value:2|c";
             var counter = new DefaultCounterMetric();
             counter.Increment(new MetricSetItem("item1", "value1"), 1);
             counter.Increment(new MetricSetItem("item2", "value2"), 1);
@@ -259,7 +259,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         public async Task Can_report_counters()
         {
             // Arrange
-            var expected = "test.test_counter.counter.value:1|c|#unit:none,timestamp:1483232461";
+            var expected = "test.test_counter.counter.value:1|c";
             var counter = new DefaultCounterMetric();
             counter.Increment(1);
             var counterValueSource = new CounterValueSource(
@@ -279,7 +279,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         public async Task Can_report_counters__when_multidimensional()
         {
             // Arrange
-            var expected = "test.test_counter.counter.value:1|c|#host:server1,env:staging,unit:none,timestamp:1483232461";
+            var expected = "test.test_counter.counter.value:1|c|#host:server1,env:staging";
             var counter = new DefaultCounterMetric();
             counter.Increment(1);
             var counterValueSource = new CounterValueSource(
@@ -299,7 +299,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         public async Task Can_report_gauges()
         {
             // Arrange
-            var expected = "test.test_gauge.gauge.value:1|g|#unit:none,timestamp:1483232461";
+            var expected = "test.test_gauge.gauge.value:1|g";
             var gauge = new FunctionGauge(() => 1);
             var gaugeValueSource = new GaugeValueSource(
                 "test gauge",
@@ -318,7 +318,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         public async Task Can_report_gauges__when_multidimensional()
         {
             // Arrange
-            var expected = "test.gauge-group.gauge.value:1|g|#host:server1,env:staging,unit:none,timestamp:1483232461";
+            var expected = "test.gauge-group.gauge.value:1|g|#host:server1,env:staging";
             var gauge = new FunctionGauge(() => 1);
             var gaugeValueSource = new GaugeValueSource(
                 "gauge-group" + MultidimensionalMetricNameSuffix,
@@ -338,7 +338,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_histogram.histogram.value:1000|h|#unit:none,timestamp:1483232461";
+                "test.test_histogram.histogram.value:1000|h";
             var histogram = new DefaultHistogramMetric(_defaultReservoir);
             histogram.Update(1000, "client1");
             var histogramValueSource = new HistogramValueSource(
@@ -359,7 +359,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_histogram.histogram.value:1000|h|#host:server1,env:staging,unit:none,timestamp:1483232461";
+                "test.test_histogram.histogram.value:1000|h|#host:server1,env:staging";
             var histogram = new DefaultHistogramMetric(_defaultReservoir);
             histogram.Update(1000, "client1");
             var histogramValueSource = new HistogramValueSource(
@@ -380,7 +380,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter.meter.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter.meter.value:1|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -403,7 +403,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter.meter.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter.meter.value:1|c|#host:server1,env:staging";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(1);
@@ -426,9 +426,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|c|#unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter.meter.value:2|c|#unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter__items.meter.item1:value1.value:1|c\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c\n" +
+                "test.test_meter.meter.value:2|c";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);
@@ -452,9 +452,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_meter__items.meter.item1:value1.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter__items.meter.item2:value2.value:1|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461\n" +
-                "test.test_meter.meter.value:2|c|#host:server1,env:staging,unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter__items.meter.item1:value1.value:1|c|#host:server1,env:staging\n" +
+                "test.test_meter__items.meter.item2:value2.value:1|c|#host:server1,env:staging\n" +
+                "test.test_meter.meter.value:2|c|#host:server1,env:staging";
             var clock = new TestClock();
             var meter = new DefaultMeterMetric(clock);
             meter.Mark(new MetricSetItem("item1", "value1"), 1);
@@ -478,7 +478,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_timer.timer.value:1000|ms|#unit:none,unit_dur:ms,unit_rate:ms,timestamp:1483232461";
+                "test.test_timer.timer.value:1000|ms";
             var clock = new TestClock();
             var timer = new DefaultTimerMetric(_defaultReservoir, clock);
             timer.Record(1000, TimeUnit.Milliseconds, "client1");
@@ -502,7 +502,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
         {
             // Arrange
             var expected =
-                "test.test_timer.timer.value:1000|ms|#host:server1,env:staging,unit:none,unit_dur:ms,unit_rate:ms,timestamp:1483232461";
+                "test.test_timer.timer.value:1000|ms|#host:server1,env:staging";
             var clock = new TestClock();
             var timer = new DefaultTimerMetric(_defaultReservoir, clock);
             timer.Record(1000, TimeUnit.Milliseconds, "client1");
@@ -529,7 +529,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
             var timeStamp = _timestamp;
 
             var expected =
-                "test.test_counter.counter.value:4|c|@0.5|#unit:none,timestamp:";
+                "test.test_counter.counter.value:4|c|@0.5";
 
             // Act
             for (var i = 0; i < 10000; ++i)
@@ -603,7 +603,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
             var timeStamp = _timestamp;
 
             var expected =
-                "test.test_meter.meter.value:4|c|#unit:none,unit_rate:ms,timestamp:1483232461";
+                "test.test_meter.meter.value:4|c";
 
             // Act
             for (var i = 0; i < 100; ++i)

--- a/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/StatsDPointTest.cs
+++ b/src/Reporting/test/App.Metrics.Reporting.StatsD.Facts/StatsDPointTest.cs
@@ -65,7 +65,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
             var result = point.Write(_options);
 
             // Assert
-            result.Should().Be("name.key:0|c|@0.1|#timestamp:1483232461");
+            result.Should().Be("name.key:0|c|@0.1");
         }
 
         [Fact]
@@ -96,9 +96,9 @@ namespace App.Metrics.Reporting.StatsD.Facts
 
             // Assert
             result.Should().Be(
-                "measurement.field1key:0|g|#timestamp:1483232461\n" +
-                "measurement.field2key:2|g|#timestamp:1483232461\n" +
-                "measurement.field3key:0|g|#timestamp:1483232461");
+                "measurement.field1key:0|g\n" +
+                "measurement.field2key:2|g\n" +
+                "measurement.field3key:0|g");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
 
             // Assert
             result.Should().Be(
-                "measurement.key:0|g|#tagkey:tagvalue,timestamp:1483232461",
+                "measurement.key:0|g|#tagkey:tagvalue",
                 "Hosted Metrics request at the moment allow tags array but its not yet used.");
         }
 
@@ -155,7 +155,7 @@ namespace App.Metrics.Reporting.StatsD.Facts
 
             // Assert
             result.Should().Be(
-                "context.measurement.key:0|g|#tagkey:tagvalue,timestamp:1483232461",
+                "context.measurement.key:0|g|#tagkey:tagvalue",
                 "Hosted Metrics request at the moment allow tags array but its not yet used.");
         }
 


### PR DESCRIPTION
### The issue or feature being addressed
I didn't file an issue for this, but: because we were adding a unique `Timestamp` tag to every single custom metric being reported to DogStatsD, this caused an explosion of unique metrics - which results in a very, very large DataDog bill.

### Details on the issue fix or feature implementation

Timestamp, Unit, Unit Duration, and so on are tags that don't add any value in DataDog so those have been removed from the DogStatsD wire format. Those have all been removed from the DogStatsD reporter for App.Metrics.StatsD.


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
