### PR TITLE
App.Metrics.Concurrency support netstandart2.0.

### DIFF
--- a/src/Concurrency/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
+++ b/src/Concurrency/src/App.Metrics.Concurrency/App.Metrics.Concurrency.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Provides useful structures for performing efficient concurrent operations. Original Project: https://github.com/etishor/ConcurrencyUtilities, including a port of Java's LongAdder and Striped64 classes</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <PackageTags>concurrency;atomic</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
### The issue or feature being addressed

- No linked issue

### Details on the issue fix or feature implementation

- Current version (4.2.0) of App.Metrics.Concurrency package contains netstandart1.1 library that requires tons of dependencies. I see no reason to support netstd1.1, but legacy. I've just added netstandart2.0 target framework to remove all deps.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
