### PR TITLE
#656 Timestamp initialized to local time but calculations performed u…

### DIFF
--- a/src/Extensions/src/App.Metrics.Extensions.Collectors/HostedServices/SystemUsageCollectorHostedService.cs
+++ b/src/Extensions/src/App.Metrics.Extensions.Collectors/HostedServices/SystemUsageCollectorHostedService.cs
@@ -25,7 +25,7 @@ namespace App.Metrics.Extensions.Collectors.HostedServices
         {
             _metrics = metrics;
             _options = options;
-            _lastTimeStamp = _process.StartTime;
+            _lastTimeStamp = TimeZoneInfo.ConvertTimeToUtc(_process.StartTime);
         }
 
         public void Dispose()


### PR DESCRIPTION
### Timestamp initialized to local time but calculations performed using UTC

[#656 ](https://github.com/AppMetrics/AppMetrics/issues/656)

### Details on the issue fix or feature implementation

Convert the Process StartTime to UTC during initialization.

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits
