### PR TITLE
#697 App.Metrics.Formatting.StatsD tests failing due to culture differences

### DIFF
--- a/src/Reporting/sandbox/MetricsStatsDSandbox/MetricsStatsDSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsStatsDSandbox/MetricsStatsDSandbox.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="App.Metrics" />
-    <PackageReference Include="App.Metrics.Reporting.Socket" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.1-dev-00044" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.1-dev-00155" />
@@ -30,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\App.Metrics.Formatting.StatsD\App.Metrics.Formatting.StatsD.csproj" />
+    <ProjectReference Include="..\..\src\App.Metrics.Reporting.Socket\App.Metrics.Reporting.Socket.csproj" />
     <ProjectReference Include="..\..\src\App.Metrics.Reporting.StatsD\App.Metrics.Reporting.StatsD.csproj" />
   </ItemGroup>
 

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultDogStatsDMetricStringSerializer.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using App.Metrics.Formatting.StatsD.Internal;
@@ -24,7 +25,7 @@ namespace App.Metrics.Formatting.StatsD
             if (point.SampleRate.HasValue && point.SampleRate < 1.0)
             {
                 builder.Append("|@");
-                builder.Append(point.SampleRate.Value.ToString("0.###############"));
+                builder.Append(point.SampleRate.Value.ToString("0.###############", NumberFormatInfo.InvariantInfo));
             }
 
             if (point.Tags != null && point.Tags.Count > 0)

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultStatsDMetricStringSerializer.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/DefaultStatsDMetricStringSerializer.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using App.Metrics.Formatting.StatsD.Internal;
@@ -24,7 +25,7 @@ namespace App.Metrics.Formatting.StatsD
             if (point.SampleRate.HasValue && point.SampleRate < 1.0)
             {
                 builder.Append("|@");
-                builder.Append(point.SampleRate.Value.ToString("0.###############"));
+                builder.Append(point.SampleRate.Value.ToString("0.###############", NumberFormatInfo.InvariantInfo));
             }
             return builder.ToString();
         }

--- a/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
+++ b/src/Reporting/src/App.Metrics.Formatting.StatsD/Internal/StatsDPointSampler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -69,7 +70,7 @@ namespace App.Metrics.Formatting.StatsD.Internal
             }
 
             tagsDictionary.TryGetValue(StatsDFormatterConstants.SampleRateTagName, out var tagSampleRateStr);
-            if (!double.TryParse(tagSampleRateStr, out var tagSampleRate))
+            if (!double.TryParse(tagSampleRateStr, NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out var tagSampleRate))
             {
                 tagSampleRate = Options.DefaultSampleRate;
             }


### PR DESCRIPTION
### The issue or feature being addressed

- [App.Metrics.Formatting.StatsD tests failing due to culture differences](https://github.com/AppMetrics/AppMetrics/issues/697)

### Details on the issue fix or feature implementation

**MetricsStatsDSandbox**: Directly referencing App.Metrics.Reporting.Socket since the dependency tries to get resolved before the actual package is created.
**App.Metrics.Formatting.StatsD**: Updated sample rate conversion to use NumberFormatInfo.InvariantInfo otherwise some systems will use a ',' (comma) instead of a '.' (decimal).

### Confirm the following

- [ X ] I have ensured that I have merged the latest changes from the dev branch
- [ X ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ X ] I have included unit tests for the issue/feature
- [ X ] I have included the github issue number in my commits
