### PR TITLE
Feature/allow multiple reporters of same type

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/Formatters/MetricsReporterCollection.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Formatters/MetricsReporterCollection.cs
@@ -18,24 +18,24 @@ namespace App.Metrics.Formatters
         {
         }
 
-        public IReportMetrics GetType<TReporter>()
+        public IEnumerable<IReportMetrics> GetType<TReporter>()
             where TReporter : IReportMetrics
         {
             return GetType(typeof(TReporter));
         }
 
-        public IReportMetrics GetType(Type reporterType)
+        public IEnumerable<IReportMetrics> GetType(Type reporterType)
         {
             for (var i = Count - 1; i >= 0; i--)
             {
                 var reporter = this[i];
                 if (reporter.GetType() == reporterType)
                 {
-                    return reporter;
+                    yield return reporter;
                 }
             }
 
-            return default;
+            yield return default;
         }
 
         public void RemoveType<TReporter>()
@@ -59,13 +59,11 @@ namespace App.Metrics.Formatters
         public void TryAdd<TReporter>(IReportMetrics reporter)
             where TReporter : IReportMetrics
         {
-            RemoveType<TReporter>();
             Add(reporter);
         }
 
         public void TryAdd(IReportMetrics reporter)
         {
-            RemoveType(reporter.GetType());
             Add(reporter);
         }
     }

--- a/src/Core/src/App.Metrics.Abstractions/Formatters/MetricsReporterCollection.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Formatters/MetricsReporterCollection.cs
@@ -34,8 +34,6 @@ namespace App.Metrics.Formatters
                     yield return reporter;
                 }
             }
-
-            yield return default;
         }
 
         public void RemoveType<TReporter>()

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsReportRunner.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricsReportRunner.cs
@@ -58,14 +58,21 @@ namespace App.Metrics.Internal
         public Task RunAsync<TMetricReporter>(CancellationToken cancellationToken = default)
             where TMetricReporter : IReportMetrics
         {
-            var reporter = _reporters.GetType<TMetricReporter>();
+            var reporters = _reporters.GetType<TMetricReporter>();
 
-            if (reporter == null)
+            if (reporters == null || !reporters.Any())
             {
                 throw new InvalidOperationException($"Metric Reporter of type {typeof(TMetricReporter)} is not available");
             }
 
-            return FlushMetrics(_metrics, cancellationToken, reporter);
+
+            var flushTasks = new List<Task>();
+            foreach(var reporter in reporters)
+            {
+                flushTasks.Add(FlushMetrics(_metrics, cancellationToken, reporter));
+            }
+
+            return Task.WhenAll(flushTasks);
         }
 
         private async Task FlushMetrics(IMetrics metrics, CancellationToken cancellationToken, IReportMetrics reporter)

--- a/src/Core/test/App.Metrics.Facts/Builders/MetricsReportingBuilderTests.cs
+++ b/src/Core/test/App.Metrics.Facts/Builders/MetricsReportingBuilderTests.cs
@@ -96,7 +96,7 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.Filter.Should().BeSameAs(filter);
+            reporter?.First()?.Filter.Should().BeSameAs(filter);
         }
 
         [Fact]
@@ -140,8 +140,8 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.Filter.Should().BeSameAs(filter);
-            reporter?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporter?.First()?.Filter.Should().BeSameAs(filter);
+            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -156,8 +156,8 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
-            reporter?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -173,9 +173,9 @@ namespace App.Metrics.Facts.Builders
             var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.Filter.Should().BeSameAs(filter);
-            reporter?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
-            reporter?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporter?.First()?.Filter.Should().BeSameAs(filter);
+            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
         }
     }
 }

--- a/src/Core/test/App.Metrics.Facts/Builders/MetricsReportingBuilderTests.cs
+++ b/src/Core/test/App.Metrics.Facts/Builders/MetricsReportingBuilderTests.cs
@@ -93,10 +93,10 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporters?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -107,10 +107,10 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporters?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
         }
 
         [Fact]
@@ -122,10 +122,10 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.Filter.Should().BeSameAs(filter);
+            reporters?.First()?.Filter.Should().BeSameAs(filter);
         }
 
         [Fact]
@@ -137,11 +137,11 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.Filter.Should().BeSameAs(filter);
-            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporters?.First()?.Filter.Should().BeSameAs(filter);
+            reporters?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -153,11 +153,11 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
-            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporters?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporters?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
         }
 
         [Fact]
@@ -170,12 +170,41 @@ namespace App.Metrics.Facts.Builders
 
             // Act
             var metrics = builder.Build();
-            var reporter = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
 
             // Assert
-            reporter?.First()?.Filter.Should().BeSameAs(filter);
-            reporter?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
-            reporter?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+            reporters?.First()?.Filter.Should().BeSameAs(filter);
+            reporters?.First()?.FlushInterval.Should().Be(TimeSpan.FromDays(1));
+            reporters?.First()?.Formatter.Should().BeOfType(typeof(MetricsJsonOutputFormatter));
+        }
+
+        [Fact]
+        public void Can_use_multiple_reporters_of_same_type()
+        {
+            // Arrange
+            var builder = new MetricsBuilder().Report.Using<TestReporter>();
+            builder.Report.Using<TestReporter>();
+
+            // Act
+            var metrics = builder.Build();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter>();
+
+            // Assert
+            reporters.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void No_reporters_of_type_returns_empty_list()
+        {
+            // Arrange
+            var builder = new MetricsBuilder().Report.Using<TestReporter>();
+
+            // Act
+            var metrics = builder.Build();
+            var reporters = (metrics.Reporters as MetricsReporterCollection)?.GetType<TestReporter2>();
+
+            // Assert
+            reporters.Should().BeEmpty();
         }
     }
 }

--- a/src/Core/test/App.Metrics.Facts/TestHelpers/TestReporter.cs
+++ b/src/Core/test/App.Metrics.Facts/TestHelpers/TestReporter.cs
@@ -56,4 +56,9 @@ namespace App.Metrics.Facts.TestHelpers
             return Task.FromResult(_pass);
         }
     }
+
+    public class TestReporter2 : TestReporter
+    {
+
+    }
 }


### PR DESCRIPTION
### Calling ToInfluxDb multiple times with different filters does not work

-  [#612](https://github.com/AppMetrics/AppMetrics/issues/612)

### Details on the issue fix or feature implementation

- Removed single reporter per reporter type restriction
- Updated DefaultReportMetricsRunner to run multiple reporters for a given reporter type

### Confirm the following

- [ X ] I have ensured that I have merged the latest changes from the dev branch
- [ X ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ X ] I have included unit tests for the issue/feature
- [ X ] I have included the github issue number in my commits
