### PR TITLE
Disable OAuthTrackingMiddleware if metrics has been disabled globally

### DIFF
--- a/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Builder/MetricsMiddlewareApplicationBuilderExtensions.cs
+++ b/src/AspNetCore/src/App.Metrics.AspNetCore.Tracking/Builder/MetricsMiddlewareApplicationBuilderExtensions.cs
@@ -114,10 +114,12 @@ namespace Microsoft.AspNetCore.Builder
         {
             EnsureRequiredServices(app);
 
+            var metricsOptions = app.ApplicationServices.GetRequiredService<MetricsOptions>();
             var trackingMiddlewareOptionsAccessor = app.ApplicationServices.GetRequiredService<IOptions<MetricsWebTrackingOptions>>();
 
             app.UseWhen(
-                context => context.OAuthClientId().IsPresent() &&
+                context => metricsOptions.Enabled &&
+                           context.OAuthClientId().IsPresent() &&
                            trackingMiddlewareOptionsAccessor.Value.OAuth2TrackingEnabled &&
                            !IsNotAnIgnoredRoute(trackingMiddlewareOptionsAccessor.Value.IgnoredRoutesRegex, context.Request.Path),
                 appBuilder =>


### PR DESCRIPTION
### The issue or feature being addressed

- No linked issue

### Details on the issue fix or feature implementation

- `OAuthTrackingMiddleware` is getting registered even `MetricsOptions.Enabled` has been set to `false`


### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
