### PR TITLE
Enabled support for v2 gc events in dotnet 5

### DIFF
--- a/src/Extensions/src/App.Metrics.Extensions.Collectors/EventListeners/GcEventListener.cs
+++ b/src/Extensions/src/App.Metrics.Extensions.Collectors/EventListeners/GcEventListener.cs
@@ -32,6 +32,7 @@ namespace App.Metrics.Extensions.Collectors.EventListeners
             switch (eventData.EventName)
             {
                 case "GCHeapStats_V1":
+                case "GCHeapStats_V2":
                     ProcessHeapStats(eventData);
                     break;
             }


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

-  #716

### Details on the issue fix or feature implementation

- Treat GC v2 events the same as v1 events. We'll still be missing the new fields but this will get us to feature-parity with what we had in previous versions of dotnet for now.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [/] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits
