### PR TITLE
Fix for #629

### DIFF
--- a/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
+++ b/src/Core/src/App.Metrics.Core/Filtering/MetricsFilter.cs
@@ -192,11 +192,19 @@ namespace App.Metrics.Filtering
                 isMatch = true;
             }
 
-            if (_tags != null && Array.Exists(_tags.ToArray(), t => sourceTags.Keys.Any(m => m == t.Key)))
+            if (_tags != null)
             {
-                isMatch = true;
-            }
-
+                foreach (var t in _tags.ToArray())
+                {
+                    var matchingKeyIx = Array.IndexOf(sourceTags.Keys, t.Key);
+                    if (matchingKeyIx > -1 && matchingKeyIx == Array.IndexOf(sourceTags.Values, t.Value))
+                    {
+                        isMatch = true;
+                        break;
+                    }
+                }
+            }            
+            
             return isMatch;
         }
     }


### PR DESCRIPTION
Given the following metrics:
```json
{
    "contexts": [
        {
            "apdexScores": [],
            "context": "MyContext",
            "counters": [],
            "gauges": [
                {
                    "value": 1,
                    "name": "NameOfMetric|PipelineId:1",
                    "tags": {
                        "pipelineId": "1"
                    }
                },
                {
                    "value": 1,
                    "name": "NameOfMetric|PipelineId:2",
                    "tags": {
                        "pipelineId": "2"
                    }
                }
            ],
            "histograms": [],
            "bucketHistograms": [],
            "meters": [],
            "timers": [],
            "bucketTimers": []
        }
    ],
    "timestamp": "2022-01-19T13:29:40.9729471Z"
}
```

Given the following code...

```cs
var filter = new MetricsFilter().WhereTaggedWithKeyValue(new TagKeyValueFilter { { "pipelineId", "`"  } });
var filteredMetrics = metrics?.Filter(filter);
```

I woulf expect `filteredMetrics` to have a single gauge value. The current dev branch returns both values as the tag-key exist for both values. The code I'm changing with this PR is either a bug (#629?) or its behavior is unintuitive.

Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- link to the issue/feature using its github issue number #number (if an issue/feature does not exist, please create it first)

### Details on the issue fix or feature implementation

- provide some details here


### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
