### PR TITLE
Issues 637 "Add metric description" implementation

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/Apdex/ApdexValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Apdex/ApdexValueSource.cs
@@ -10,8 +10,9 @@ namespace App.Metrics.Apdex
             string name,
             IMetricValueProvider<ApdexValue> value,
             MetricTags tags,
-            bool resetOnReporting = false)
-            : base(name, value, Unit.Results, tags, resetOnReporting)
+            bool resetOnReporting = false,
+            string description = "")
+            : base(name, value, Unit.Results, tags, resetOnReporting, description)
         {}
     }
 }

--- a/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketHistogram/BucketHistogramValueSource.cs
@@ -13,8 +13,9 @@ namespace App.Metrics.BucketHistogram
             string name,
             IMetricValueProvider<BucketHistogramValue> valueProvider,
             Unit unit,
-            MetricTags tags)
-            : base(name, valueProvider, unit, tags)
+            MetricTags tags,
+            string description = "")
+            : base(name, valueProvider, unit, tags, description: description)
         {
         }
     }

--- a/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/BucketTimer/BucketTimerValueSource.cs
@@ -15,8 +15,9 @@ namespace App.Metrics.BucketTimer
             Unit unit,
             TimeUnit rateUnit,
             TimeUnit durationUnit,
-            MetricTags tags)
-            : base(name, new ScaledValueProvider<BucketTimerValue>(value, v => v.Scale(rateUnit, durationUnit)), unit, tags)
+            MetricTags tags,
+            string description = "")
+            : base(name, new ScaledValueProvider<BucketTimerValue>(value, v => v.Scale(rateUnit, durationUnit)), unit, tags, description: description)
         {
             DurationUnit = durationUnit;
             RateUnit = rateUnit;

--- a/src/Core/src/App.Metrics.Abstractions/Counter/CounterValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Counter/CounterValueSource.cs
@@ -13,6 +13,7 @@ namespace App.Metrics.Counter
         ///     Initializes a new instance of the <see cref="CounterValueSource" /> class.
         /// </summary>
         /// <param name="name">The name.</param>
+        /// <param name="description">The description.</param>
         /// <param name="value">The value.</param>
         /// <param name="unit">The unit.</param>
         /// <param name="tags">The tags.</param>
@@ -26,8 +27,9 @@ namespace App.Metrics.Counter
             MetricTags tags,
             bool resetOnReporting = false,
             bool reportItemPercentages = true,
-            bool reportSetItems = true)
-            : base(name, value, unit, tags, resetOnReporting)
+            bool reportSetItems = true,
+            string description = "")
+            : base(name, value, unit, tags, resetOnReporting, description)
         {
             ReportItemPercentages = reportItemPercentages;
             ReportSetItems = reportSetItems;

--- a/src/Core/src/App.Metrics.Abstractions/Gauge/GaugeValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Gauge/GaugeValueSource.cs
@@ -14,8 +14,9 @@ namespace App.Metrics.Gauge
             IMetricValueProvider<double> value,
             Unit unit,
             MetricTags tags,
-            bool restOnReporting = false)
-            : base(name, value, unit, tags, restOnReporting)
+            bool restOnReporting = false,
+            string description = "")
+            : base(name, value, unit, tags, restOnReporting, description)
         {
         }
     }

--- a/src/Core/src/App.Metrics.Abstractions/Histogram/HistogramValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Histogram/HistogramValueSource.cs
@@ -14,8 +14,9 @@ namespace App.Metrics.Histogram
             IMetricValueProvider<HistogramValue> valueProvider,
             Unit unit,
             MetricTags tags,
-            bool restOnReporting = false)
-            : base(name, valueProvider, unit, tags, restOnReporting)
+            bool restOnReporting = false,
+            string description = "")
+            : base(name, valueProvider, unit, tags, restOnReporting, description)
         {
         }
     }

--- a/src/Core/src/App.Metrics.Abstractions/Meter/MeterValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Meter/MeterValueSource.cs
@@ -16,8 +16,9 @@ namespace App.Metrics.Meter
             TimeUnit rateUnit,
             MetricTags tags,
             bool resetOnReporting = false,
-            bool reportSetItems = true)
-            : base(name, new ScaledValueProvider<MeterValue>(value, v => v.Scale(rateUnit)), unit, tags, resetOnReporting)
+            bool reportSetItems = true,
+            string description = "")
+            : base(name, new ScaledValueProvider<MeterValue>(value, v => v.Scale(rateUnit)), unit, tags, resetOnReporting, description)
         {
             RateUnit = rateUnit;
             ReportSetItems = reportSetItems;

--- a/src/Core/src/App.Metrics.Abstractions/MetricValueOptionsBase.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricValueOptionsBase.cs
@@ -9,7 +9,11 @@ namespace App.Metrics
     /// </summary>
     public abstract class MetricValueOptionsBase
     {
-        protected MetricValueOptionsBase() { MeasurementUnit = Unit.None; }
+        protected MetricValueOptionsBase()
+        {
+            MeasurementUnit = Unit.None;
+            Description = string.Empty;
+        }
 
         /// <summary>
         ///     Gets or sets the context for which the metric belongs e.g. Application.WebRequests
@@ -35,6 +39,14 @@ namespace App.Metrics
         ///     The name.
         /// </value>
         public string Name { get; set; }
+        
+        /// <summary>
+        ///     Gets or sets the description of the Metric being measure />
+        /// </summary>
+        /// <value>
+        ///     The name.
+        /// </value>
+        public string Description { get; set; }
 
         /// <summary>
         ///     Gets or sets the <see cref="MetricTags" /> associated with the metric, this is useful for grouping metrics when

--- a/src/Core/src/App.Metrics.Abstractions/MetricValueSourceBase{T}.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricValueSourceBase{T}.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Runtime.Serialization;
 using App.Metrics.Formatters;
 
 namespace App.Metrics
@@ -14,9 +15,15 @@ namespace App.Metrics
     /// <typeparam name="T">Type of the metric value</typeparam>
     public abstract class MetricValueSourceBase<T>
     {
-        protected MetricValueSourceBase(string name, IMetricValueProvider<T> valueProvider, Unit unit, MetricTags tags, bool resetOnReporting = false)
+        protected MetricValueSourceBase(
+            string name, IMetricValueProvider<T> valueProvider,
+            Unit unit,
+            MetricTags tags,
+            bool resetOnReporting = false,
+            string description = "")
         {
             Name = name;
+            Description = description;
             Unit = unit;
             ValueProvider = valueProvider;
             Tags = tags;
@@ -54,6 +61,14 @@ namespace App.Metrics
         ///     The name.
         /// </value>
         public string Name { get; }
+        
+        /// <summary>
+        ///     Gets the Description of the metric.
+        /// </summary>
+        /// <value>
+        ///     The description.
+        /// </value>
+        public string Description { get; }
 
         /// <summary>
         ///     Gets the Tags associated with the metric.

--- a/src/Core/src/App.Metrics.Abstractions/Timer/TimerValueSource.cs
+++ b/src/Core/src/App.Metrics.Abstractions/Timer/TimerValueSource.cs
@@ -16,8 +16,9 @@ namespace App.Metrics.Timer
             TimeUnit rateUnit,
             TimeUnit durationUnit,
             MetricTags tags,
-            bool restOnReporting = false)
-            : base(name, new ScaledValueProvider<TimerValue>(value, v => v.Scale(rateUnit, durationUnit)), unit, tags, restOnReporting)
+            bool restOnReporting = false,
+            string description = "")
+            : base(name, new ScaledValueProvider<TimerValue>(value, v => v.Scale(rateUnit, durationUnit)), unit, tags, restOnReporting, description)
         {
             RateUnit = rateUnit;
             DurationUnit = durationUnit;

--- a/src/Core/src/App.Metrics.Core/Internal/DefaultMetricContextRegistry.cs
+++ b/src/Core/src/App.Metrics.Core/Internal/DefaultMetricContextRegistry.cs
@@ -93,14 +93,15 @@ namespace App.Metrics.Internal
                 metricName,
                 () =>
                 {
-                    Logger.Trace("Adding Apdex {Name} - {@Options} {MesurementUnit} {@Tags}", metricName, options, options.MeasurementUnit.ToString(), allTags.ToDictionary());
+                    Logger.Trace("Adding Apdex {Name} - {@Options} {MeasurementUnit} {@Tags}", metricName, options, options.MeasurementUnit.ToString(), allTags.ToDictionary());
 
                     var apdex = builder();
                     var valueSource = new ApdexValueSource(
                         metricName,
                         apdex,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((IApdex)apdex, valueSource);
                 });
         }
@@ -123,7 +124,8 @@ namespace App.Metrics.Internal
                         metricName,
                         apdex,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((IApdex)apdex, valueSource);
                 });
         }
@@ -161,7 +163,8 @@ namespace App.Metrics.Internal
                         allTags,
                         options.ResetOnReporting,
                         options.ReportItemPercentages,
-                        options.ReportSetItems);
+                        options.ReportSetItems,
+                        options.Description);
                     return Tuple.Create((ICounter)counter, valueSource);
                 });
         }
@@ -187,7 +190,8 @@ namespace App.Metrics.Internal
                         allTags,
                         options.ResetOnReporting,
                         options.ReportItemPercentages,
-                        options.ReportSetItems);
+                        options.ReportSetItems,
+                        options.Description);
                     return Tuple.Create((ICounter)counter, valueSource);
                 });
         }
@@ -210,7 +214,8 @@ namespace App.Metrics.Internal
                         gauge,
                         options.MeasurementUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((IGauge)gauge, valueSource);
                 });
         }
@@ -234,7 +239,8 @@ namespace App.Metrics.Internal
                         gauge,
                         options.MeasurementUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
 
                     return Tuple.Create((IGauge)gauge, valueSource);
                 });
@@ -258,7 +264,8 @@ namespace App.Metrics.Internal
                         histogram,
                         options.MeasurementUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((IHistogram)histogram, valueSource);
                 });
         }
@@ -282,7 +289,8 @@ namespace App.Metrics.Internal
                         histogram,
                         options.MeasurementUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((IHistogram)histogram, valueSource);
                 });
         }
@@ -304,7 +312,8 @@ namespace App.Metrics.Internal
                         metricName,
                         histogram,
                         options.MeasurementUnit,
-                        allTags);
+                        allTags,
+                        options.Description);
                     return Tuple.Create((IBucketHistogram)histogram, valueSource);
                 });
         }
@@ -327,7 +336,8 @@ namespace App.Metrics.Internal
                         metricName,
                         histogram,
                         options.MeasurementUnit,
-                        allTags);
+                        allTags,
+                        options.Description);
                     return Tuple.Create((IBucketHistogram)histogram, valueSource);
                 });
         }
@@ -352,7 +362,8 @@ namespace App.Metrics.Internal
                         options.RateUnit,
                         allTags,
                         options.ResetOnReporting,
-                        options.ReportSetItems);
+                        options.ReportSetItems,
+                        options.Description);
                     return Tuple.Create((IMeter)meter, valueSource);
                 });
         }
@@ -378,7 +389,8 @@ namespace App.Metrics.Internal
                         options.RateUnit,
                         allTags,
                         options.ResetOnReporting,
-                        options.ReportSetItems);
+                        options.ReportSetItems,
+                        options.Description);
                     return Tuple.Create((IMeter)meter, valueSource);
                 });
         }
@@ -397,13 +409,14 @@ namespace App.Metrics.Internal
 
                     var timer = builder();
                     var valueSource = new TimerValueSource(
-                    metricName,
+                        metricName,
                         timer,
                         options.MeasurementUnit,
                         options.RateUnit,
                         options.DurationUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((ITimer)timer, valueSource);
                 });
         }
@@ -429,7 +442,8 @@ namespace App.Metrics.Internal
                         options.RateUnit,
                         options.DurationUnit,
                         allTags,
-                        options.ResetOnReporting);
+                        options.ResetOnReporting,
+                        options.Description);
                     return Tuple.Create((ITimer)timer, valueSource);
                 });
         }
@@ -448,12 +462,13 @@ namespace App.Metrics.Internal
 
                     var timer = builder();
                     var valueSource = new BucketTimerValueSource(
-                    metricName,
+                        metricName,
                         timer,
                         options.MeasurementUnit,
                         options.RateUnit,
                         options.DurationUnit,
-                        allTags);
+                        allTags,
+                        options.Description);
                     return Tuple.Create((ITimer)timer, valueSource);
                 });
         }
@@ -478,7 +493,8 @@ namespace App.Metrics.Internal
                         options.MeasurementUnit,
                         options.RateUnit,
                         options.DurationUnit,
-                        allTags);
+                        allTags,
+                        options.Description);
                     return Tuple.Create((ITimer)timer, valueSource);
                 });
         }

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/ApdexValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/ApdexValueSourceSerializationExtensions.cs
@@ -15,7 +15,7 @@ namespace App.Metrics.Apdex
         public static ApdexValueSource FromSerializableMetric(this ApdexMetric source)
         {
             var counterValue = new ApdexValue(source.Score, source.Satisfied, source.Tolerating, source.Frustrating, source.SampleSize);
-            return new ApdexValueSource(source.Name, ConstantValue.Provider(counterValue), source.Tags.FromDictionary());
+            return new ApdexValueSource(source.Name, ConstantValue.Provider(counterValue), source.Tags.FromDictionary(), description:source.Description);
         }
 
         public static IEnumerable<ApdexValueSource> FromSerializableMetric(this IEnumerable<ApdexMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/CounterValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/CounterValueSourceSerializationExtensions.cs
@@ -54,7 +54,8 @@ namespace App.Metrics.Counter
                 source.Name,
                 ConstantValue.Provider(counterValue),
                 source.Unit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                description: source.Description);
         }
 
         public static IEnumerable<CounterValueSource> FromSerializableMetric(this IEnumerable<CounterMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/GaugeValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/GaugeValueSourceSerializationExtensions.cs
@@ -16,8 +16,8 @@ namespace App.Metrics.Gauge
         {
             var tags = source.Tags.FromDictionary();
             return source.Value.HasValue
-                ? new GaugeValueSource(source.Name, ConstantValue.Provider(source.Value.Value), source.Unit, tags)
-                : new GaugeValueSource(source.Name, null, source.Unit, tags);
+                ? new GaugeValueSource(source.Name, ConstantValue.Provider(source.Value.Value), source.Unit, tags, description: source.Description)
+                : new GaugeValueSource(source.Name, null, source.Unit, tags, description: source.Description);
         }
 
         public static IEnumerable<GaugeValueSource> FromSerializableMetric(this IEnumerable<GaugeMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/HistogramValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/HistogramValueSourceSerializationExtensions.cs
@@ -36,10 +36,11 @@ namespace App.Metrics.Histogram
                 source.SampleSize);
 
             return new HistogramValueSource(
-                source.Name,
+                source.Name, 
                 ConstantValue.Provider(histogramValue),
                 source.Unit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                description: source.Description);
         }
 
         public static BucketHistogramValueSource FromSerializableMetric(this BucketHistogramMetric source)
@@ -50,10 +51,11 @@ namespace App.Metrics.Histogram
                 new ReadOnlyDictionary<double, double>(source.Buckets));
 
             return new BucketHistogramValueSource(
-                source.Name,
+                source.Name, 
                 ConstantValue.Provider(histogramValue),
                 source.Unit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                source.Description);
         }
 
         public static IEnumerable<HistogramValueSource> FromSerializableMetric(this IEnumerable<HistogramMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/MeterValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/MeterValueSourceSerializationExtensions.cs
@@ -47,7 +47,8 @@ namespace App.Metrics.Meter
                 ConstantValue.Provider(meterValue),
                 source.Unit,
                 rateUnit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                description: source.Description);
         }
 
         public static IEnumerable<MeterValueSource> FromSerializableMetric(this IEnumerable<MeterMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/Extensions/TimerValueSourceSerializationExtensions.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/Extensions/TimerValueSourceSerializationExtensions.cs
@@ -57,7 +57,8 @@ namespace App.Metrics.Timer
                 source.Unit,
                 rateUnit,
                 durationUnit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                description: source.Description);
         }
         public static BucketTimerValueSource FromSerializableMetric(this BucketTimerMetric source)
         {
@@ -85,7 +86,8 @@ namespace App.Metrics.Timer
                 source.Unit,
                 rateUnit,
                 durationUnit,
-                source.Tags.FromDictionary());
+                source.Tags.FromDictionary(),
+                source.Description);
         }
 
         public static IEnumerable<TimerValueSource> FromSerializableMetric(this IEnumerable<TimerMetric> source)

--- a/src/Core/src/App.Metrics.Formatters.Json/MetricBase.cs
+++ b/src/Core/src/App.Metrics.Formatters.Json/MetricBase.cs
@@ -9,6 +9,8 @@ namespace App.Metrics.Formatters.Json
     public abstract class MetricBase
     {
         public string Name { get; set; }
+        
+        public string Description { get; set; }
 
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
 

--- a/src/Reporting/Reporting.sln
+++ b/src/Reporting/Reporting.sln
@@ -142,6 +142,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsInfluxDB2SandboxMvc"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App.Metrics.Reporting.InfluxDB2.Facts", "test\App.Metrics.Reporting.InfluxDB2.Facts\App.Metrics.Reporting.InfluxDB2.Facts.csproj", "{C4B12D2E-75D3-4800-B116-77851E4D1A2E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.Metrics.Formatters.Prometheus.Facts", "test\App.Metrics.Formatters.Prometheus.Facts\App.Metrics.Formatters.Prometheus.Facts.csproj", "{5E6D167B-E6D1-4853-A54C-DD53CB3416EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -316,6 +318,10 @@ Global
 		{C4B12D2E-75D3-4800-B116-77851E4D1A2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4B12D2E-75D3-4800-B116-77851E4D1A2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4B12D2E-75D3-4800-B116-77851E4D1A2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E6D167B-E6D1-4853-A54C-DD53CB3416EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E6D167B-E6D1-4853-A54C-DD53CB3416EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E6D167B-E6D1-4853-A54C-DD53CB3416EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E6D167B-E6D1-4853-A54C-DD53CB3416EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -382,6 +388,7 @@ Global
 		{8B32FBD8-2F3F-40EF-A672-8E1E9E16148F} = {9D00C681-A88C-450E-B83E-E3BFF942F82A}
 		{74C314BC-394A-4A09-B739-03D4BE86DBB0} = {9D00C681-A88C-450E-B83E-E3BFF942F82A}
 		{C4B12D2E-75D3-4800-B116-77851E4D1A2E} = {3B064A0E-B6B6-41A3-BFC1-F4734E16EBA3}
+		{5E6D167B-E6D1-4853-A54C-DD53CB3416EF} = {DC95E9C9-286C-45D6-BE58-83E3F42DB96D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {492C97B1-706A-4357-B3F7-EFB6AFB1F6C6}

--- a/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
+++ b/src/Reporting/sandbox/MetricsPrometheusSandbox/MetricsPrometheusSandbox.csproj
@@ -12,7 +12,9 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<Content Include="appsettings.json" />
+		<Content Include="appsettings.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
+++ b/src/Reporting/src/App.Metrics.Formatters.Prometheus/Internal/Extensions/MetricDataValueSourceExtensions.cs
@@ -24,7 +24,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, metricGroup.Key),
-                                               type = MetricType.GAUGE
+                                               type = MetricType.GAUGE,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
                     foreach (var metric in metricGroup)
                     {
@@ -40,7 +41,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, metricGroup.Key),
-                                               type = MetricType.GAUGE
+                                               type = MetricType.GAUGE,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
                     foreach (var metric in metricGroup)
                     {
@@ -56,7 +58,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, metricGroup.Key),
-                                               type = MetricType.GAUGE
+                                               type = MetricType.GAUGE,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
 
                     foreach (var metric in metricGroup)
@@ -73,7 +76,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, $"{metricGroup.Key}_total"),
-                                               type = MetricType.COUNTER
+                                               type = MetricType.COUNTER,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
 
                     foreach (var metric in metricGroup)
@@ -90,7 +94,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, metricGroup.Key),
-                                               type = MetricType.SUMMARY
+                                               type = MetricType.SUMMARY,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
 
                     foreach (var timer in metricGroup)
@@ -107,7 +112,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                     {
                         name = metricNameFormatter(group.Context, metricGroup.Key),
-                        type = MetricType.HISTOGRAM
+                        type = MetricType.HISTOGRAM,
+                        help = ExtractMetricDescription(metricGroup)
                     };
 
                     foreach (var timer in metricGroup)
@@ -124,7 +130,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                                            {
                                                name = metricNameFormatter(group.Context, metricGroup.Key),
-                                               type = MetricType.SUMMARY
+                                               type = MetricType.SUMMARY,
+                                               help = ExtractMetricDescription(metricGroup)
                                            };
 
                     foreach (var timer in metricGroup)
@@ -141,7 +148,8 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
                     var promMetricFamily = new MetricFamily
                     {
                         name = metricNameFormatter(group.Context, metricGroup.Key),
-                        type = MetricType.HISTOGRAM
+                        type = MetricType.HISTOGRAM,
+                        help = ExtractMetricDescription(metricGroup)
                     };
 
                     foreach (var timer in metricGroup)
@@ -154,6 +162,14 @@ namespace App.Metrics.Formatters.Prometheus.Internal.Extensions
             }
 
             return result;
+        }
+
+        private static string ExtractMetricDescription<T>(IEnumerable<MetricValueSourceBase<T>> group)
+        {
+             var description = group
+                .FirstOrDefault(metricGroupItem => !string.IsNullOrWhiteSpace(metricGroupItem.Description))?
+                .Description;
+             return description ?? string.Empty;
         }
     }
 }

--- a/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/App.Metrics.Formatters.Prometheus.Facts.csproj
+++ b/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/App.Metrics.Formatters.Prometheus.Facts.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\App.Metrics.Formatters.Prometheus\App.Metrics.Formatters.Prometheus.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/TestClock.cs
+++ b/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/TestClock.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+
+namespace App.Metrics.Formatters.Prometheus.Facts
+{
+    sealed class TestClock : IClock
+    {
+        public event EventHandler Advanced;
+
+        public long Nanoseconds { get; private set; }
+
+        public long Seconds => TimeUnit.Nanoseconds.ToSeconds(Nanoseconds);
+
+        public DateTime UtcDateTime => new DateTime(Nanoseconds / 100L, DateTimeKind.Utc);
+
+        public void Advance(TimeUnit unit, long value)
+        {
+            Nanoseconds += unit.ToNanoseconds(value);
+            Advanced?.Invoke(this, EventArgs.Empty);
+        }
+
+        public string FormatTimestamp(DateTime timestamp) { return timestamp.ToString("yyyy-MM-ddTHH:mm:ss.ffffK", CultureInfo.InvariantCulture); }
+    }
+}

--- a/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/TestMetricsPrometheusTextOutputFormatter.cs
+++ b/src/Reporting/test/App.Metrics.Formatters.Prometheus.Facts/TestMetricsPrometheusTextOutputFormatter.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using App.Metrics.Apdex;
+using App.Metrics.BucketHistogram;
+using App.Metrics.BucketTimer;
+using App.Metrics.Counter;
+using App.Metrics.Gauge;
+using App.Metrics.Histogram;
+using App.Metrics.Meter;
+using App.Metrics.ReservoirSampling;
+using App.Metrics.ReservoirSampling.ExponentialDecay;
+using App.Metrics.Timer;
+using FluentAssertions;
+using Xunit;
+
+namespace App.Metrics.Formatters.Prometheus.Facts
+{
+    public class TestMetricsPrometheusTextOutputFormatter
+    {
+        private readonly IClock _clock = new TestClock();
+        private readonly IReservoir _defaultReservoir = new DefaultForwardDecayingReservoir();
+
+        private readonly MetricsPrometheusTextOutputFormatter _metricsPrometheusTextOutputFormatter =
+            new MetricsPrometheusTextOutputFormatter();
+
+        private readonly DateTime _timestamp = new DateTime(2017, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+
+        [Fact]
+        public async Task Apdex_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_apdex apdex description\n# TYPE test_apdex gauge\ntest_apdex 0\n\n";
+
+            var apdex = new DefaultApdexMetric(_defaultReservoir, _clock, false);
+            var apdexValueSource = new ApdexValueSource(
+                "apdex",
+                ConstantValue.Provider(apdex.Value),
+                MetricTags.Empty,
+                description: "apdex description");
+
+            var output = await GetFormatterOutput(CreateValueSource(apdexScores: apdexValueSource));
+            output.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task Counter_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_counter counter_description\n# TYPE test_counter gauge\ntest_counter 0\n\n";
+
+            var counter = new DefaultCounterMetric();
+            var counterValueSource = new CounterValueSource("counter", ConstantValue.Provider(counter.Value),
+                Unit.Calls,
+                MetricTags.Empty,
+                description: "counter_description");
+
+            var output = await GetFormatterOutput(CreateValueSource(counters: counterValueSource));
+            output.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task Bucket_histogram_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_bucket_histogram bucket histogram description\n# TYPE test_bucket_histogram histogram\ntest_bucket_histogram_sum 0\ntest_bucket_histogram_count 0\ntest_bucket_histogram_bucket{le=\"0.5\"} 0\ntest_bucket_histogram_bucket{le=\"+Inf\"} 0\n\n";
+            var bucketHistogram = new DefaultBucketHistogramMetric(new[] {0.5});
+            var bucketHistogramValueSource = new BucketHistogramValueSource("bucket_histogram",
+                ConstantValue.Provider(bucketHistogram.Value),
+                Unit.Calls,
+                MetricTags.Empty,
+                "bucket histogram description");
+            var metricsContextValueSource = CreateValueSource(bucketHistograms: bucketHistogramValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task Bucket_timer_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_bucket_timer bucket timer description\n# TYPE test_bucket_timer histogram\ntest_bucket_timer_sum 0\ntest_bucket_timer_count 0\ntest_bucket_timer_bucket{le=\"0.5\"} 0\ntest_bucket_timer_bucket{le=\"+Inf\"} 0\n\n";
+            var bucketHistogram = new DefaultBucketHistogramMetric(new[] {0.5});
+            var bucketTimer = new DefaultBucketTimerMetric(bucketHistogram,_clock,TimeUnit.Milliseconds);
+            var bucketTimerValueSource = new BucketTimerValueSource(
+                "bucket_timer",
+                ConstantValue.Provider(bucketTimer.Value),
+                Unit.Calls,
+                TimeUnit.Milliseconds,
+                TimeUnit.Milliseconds,
+                MetricTags.Empty,
+                "bucket timer description");
+            var metricsContextValueSource = CreateValueSource(bucketTimers: bucketTimerValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task Gauge_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_gauge gauge description\n# TYPE test_gauge gauge\ntest_gauge 1\n\n";
+            var gauge = new FunctionGauge(() => 1);
+            var gaugeValueSource = new GaugeValueSource(
+                "gauge",
+                ConstantValue.Provider(gauge.Value),
+                Unit.None,
+                MetricTags.Empty,
+                description: "gauge description");
+            var metricsContextValueSource = CreateValueSource(gauges: gaugeValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task Histogram_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_histogram histogram description\n# TYPE test_histogram summary\ntest_histogram_sum 0\ntest_histogram_count 0\ntest_histogram{quantile=\"0.5\"} 0\ntest_histogram{quantile=\"0.75\"} 0\ntest_histogram{quantile=\"0.95\"} 0\ntest_histogram{quantile=\"0.99\"} 0\n\n";
+            var histogram = new DefaultHistogramMetric(_defaultReservoir);
+            var histogramValueSource = new HistogramValueSource(
+                "histogram",
+                ConstantValue.Provider(histogram.Value),
+                Unit.None,
+                MetricTags.Empty,
+                description: "histogram description");
+            
+            var metricsContextValueSource = CreateValueSource(histograms: histogramValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task Meter_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_meter_total meter description\n# TYPE test_meter_total counter\ntest_meter_total 0\n\n";
+            var clock = new TestClock();
+            var meter = new DefaultMeterMetric(clock);
+            
+            var meterValueSource = new MeterValueSource(
+                "meter",
+                ConstantValue.Provider(meter.Value),
+                Unit.None,
+                TimeUnit.Milliseconds,
+                MetricTags.Empty,
+                description: "meter description");
+            
+            var metricsContextValueSource = CreateValueSource(meters: meterValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+        
+        [Fact]
+        public async Task Timer_output_contains_description()
+        {
+            const string expected =
+                "# HELP test_timer timer description\n# TYPE test_timer summary\ntest_timer_sum 0\ntest_timer_count 0\ntest_timer{quantile=\"0.5\"} 0\ntest_timer{quantile=\"0.75\"} 0\ntest_timer{quantile=\"0.95\"} 0\ntest_timer{quantile=\"0.99\"} 0\n\n";
+            var clock = new TestClock();
+            var timer = new DefaultTimerMetric(_defaultReservoir, clock);
+            var timerValueSource = new TimerValueSource(
+                "timer",
+                ConstantValue.Provider(timer.Value),
+                Unit.None,
+                TimeUnit.Milliseconds,
+                TimeUnit.Milliseconds,
+                MetricTags.Empty,
+                description: "timer description");
+
+            // Act
+            var metricsContextValueSource = CreateValueSource(timers: timerValueSource);
+
+            var output = await GetFormatterOutput(metricsContextValueSource);
+            output.Should().BeEquivalentTo(expected);
+        }
+
+        private async Task<string> GetFormatterOutput(MetricsContextValueSource metricsContextValueSource)
+        {
+            await using var stream = new MemoryStream();
+            await _metricsPrometheusTextOutputFormatter.WriteAsync(stream,
+                new MetricsDataValueSource(_timestamp,
+                    new[] {metricsContextValueSource}));
+
+            var output = Encoding.UTF8.GetString(stream.ToArray());
+            return output;
+        }
+
+        private static MetricsContextValueSource CreateValueSource(
+            string context="test",
+            GaugeValueSource gauges = null,
+            CounterValueSource counters = null,
+            MeterValueSource meters = null,
+            HistogramValueSource histograms = null,
+            BucketHistogramValueSource bucketHistograms = null,
+            TimerValueSource timers = null,
+            BucketTimerValueSource bucketTimers = null,
+            ApdexValueSource apdexScores = null)
+        {
+            var gaugeValues = gauges != null ? new[] {gauges} : Enumerable.Empty<GaugeValueSource>();
+            var counterValues = counters != null ? new[] {counters} : Enumerable.Empty<CounterValueSource>();
+            var meterValues = meters != null ? new[] {meters} : Enumerable.Empty<MeterValueSource>();
+            var histogramValues = histograms != null ? new[] {histograms} : Enumerable.Empty<HistogramValueSource>();
+            var bucketHistogramValues = bucketHistograms != null
+                ? new[] {bucketHistograms}
+                : Enumerable.Empty<BucketHistogramValueSource>();
+            var timerValues = timers != null ? new[] {timers} : Enumerable.Empty<TimerValueSource>();
+            var bucketTimerValues =
+                bucketTimers != null ? new[] {bucketTimers} : Enumerable.Empty<BucketTimerValueSource>();
+            var apdexScoreValues = apdexScores != null ? new[] {apdexScores} : Enumerable.Empty<ApdexValueSource>();
+
+            return new MetricsContextValueSource(
+                context,
+                gaugeValues,
+                counterValues,
+                meterValues,
+                histogramValues,
+                bucketHistogramValues,
+                timerValues,
+                bucketTimerValues,
+                apdexScoreValues);
+        }
+    }
+}


### PR DESCRIPTION
#637 
### Details on the issue fix or feature implementation

I saw in the protobuf contracts for Prometheus the `help` field exists and is even written to the output, but in the `Options` classes for all metrics it is absent. So I decided that I can add the "Description" property to the Options and init its value with Options of the appropriate metric.

Also, I've added unit tests that check how the output formatting looks.

Also, I've fixed the small issues with the Prometheus sandbox app
### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
