### PR TITLE
#738 Fix wrong URL in GrafanaCloudHostedMetrics

### DIFF
--- a/src/Reporting/src/App.Metrics.Reporting.GrafanaCloudHostedMetrics/Client/DefaultHostedMetricsHttpClient.cs
+++ b/src/Reporting/src/App.Metrics.Reporting.GrafanaCloudHostedMetrics/Client/DefaultHostedMetricsHttpClient.cs
@@ -56,7 +56,7 @@ namespace App.Metrics.Reporting.GrafanaCloudHostedMetrics.Client
             {
                 var content = new StringContent(payload);
                 content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-                var response = await _client.PostAsync("/metrics", content, cancellationToken);
+                var response = await _client.PostAsync("metrics", content, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
### The issue or feature being addressed

#738

### Details on the issue fix or feature implementation

The problem describe in original issues exists because we have following code:
var response = await _client.PostAsync("/metrics", content, cancellationToken);
client is initialized with your Url which looks like :
              "https://graphite-prod-01-eu-west-0.grafana.net/graphite"

then when you inspect the request in f.e. fidler you would expect the payload to be sent to https://graphite-prod-01-eu-west-0.grafana.net/graphite/metrics. In fact is sent to https://graphite-prod-01-eu-west-0.grafana.net/metrics

this behavior of http is described here:
https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working

the provided fix makes we're pushing the metrics to the address that grafana cloud expects

### Confirm the following

- [X ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [X ] I have included the github issue number in my commits
