### PR TITLE
Fix NRE in MetricsTags' GetHashCode

### DIFF
--- a/src/Core/src/App.Metrics.Abstractions/MetricTags.cs
+++ b/src/Core/src/App.Metrics.Abstractions/MetricTags.cs
@@ -227,7 +227,7 @@ namespace App.Metrics
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            if (_key == null)
+            if (_keys == null)
             {
                 return _key?.GetHashCode() ?? 0;
             }

--- a/src/Core/test/App.Metrics.Facts/Tagging/MetricTagsTests.cs
+++ b/src/Core/test/App.Metrics.Facts/Tagging/MetricTagsTests.cs
@@ -311,6 +311,15 @@ namespace App.Metrics.Facts.Tagging
             tags.Values.Should().Equal("machine-1", "machine-2");
         }
 
+        [Fact]
+        public void GetHashCode_does_not_throw_NRE()
+        {
+            Func<int> withKey = () => new MetricTags("tag1", "value1").GetHashCode();
+            Func<int> withKeys = () => new MetricTags(new [] { "tag2" }, new [] { "value2" }).GetHashCode();
+            withKey.Should().NotThrow<NullReferenceException>();
+            withKeys.Should().NotThrow<NullReferenceException>();
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
### The issue or feature being addressed

This fixes AppMetrics/AppMetrics#703.

### Details on the issue fix or feature implementation

A typo in `MetricTags.GetHashCode` results in a NRE regardless of whether `_key` or `_keys` is set.

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits
