### PR TITLE
Fix arithmetic overflow at all default reservoir

### DIFF
--- a/src/Core/src/App.Metrics.Core/ReservoirSampling/Abstractions/ReservoirBase.cs
+++ b/src/Core/src/App.Metrics.Core/ReservoirSampling/Abstractions/ReservoirBase.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using App.Metrics.Concurrency;
+
+namespace App.Metrics.ReservoirSampling.Abstractions
+{
+    /// <summary>
+    /// Base abstract reservoir
+    /// </summary>
+    public abstract class ReservoirBase<TValues> : IReservoir
+        where TValues : ICollection
+    {
+        protected TValues ValuesCollection;
+        protected AtomicLong Count = new AtomicLong(0);
+        protected AtomicDouble Sum = new AtomicDouble(0.0);        
+        
+        /// <summary>
+        ///     Gets the size.
+        /// </summary>
+        /// <value>
+        ///     The size.
+        /// </value>
+        // ReSharper disable once MemberCanBeProtected.Global
+        protected internal virtual int Size
+        {
+            get
+            {
+                long totalCount = Count.GetValue();
+                int bufferCount = ValuesCollection.Count;
+                // total count will be always lower than int.MaxValue, casting is safe 
+                return totalCount <= bufferCount ? (int)totalCount : bufferCount;
+            }
+        }
+
+        protected ReservoirBase(TValues valuesCollection)
+        {
+            ValuesCollection = valuesCollection;
+        }
+        
+        /// <inheritdoc cref="IReservoir"/>
+        public abstract IReservoirSnapshot GetSnapshot(bool resetReservoir);
+
+        /// <inheritdoc />
+        public IReservoirSnapshot GetSnapshot() => GetSnapshot(false);
+
+        public abstract void Reset();
+
+        public abstract void Update(long value, string userValue);
+
+        public void Update(long value) => Update(value, default);
+    }
+}


### PR DESCRIPTION
Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- Alreary was the same PR #632. But it fix only `DefaultAlgorithmRReservoir`. Same problem exists for other reservoirs. 
- When reservoir processed more than int.MaxValue elements, this unchecked cast will result in negative value of a size.
During snapshot creation array of UserValueWrappers will be created with negative size, thus resulting into OverflowException.
Now during casting total count to int it will be always lower than int.MaxValue, because it is compared to value's size.

### Details on the issue fix or feature implementation

- Added base abstract generic reservoir `ReservoirBase` with fixed problem.
- All `DefaultXXXReservoir` now inherited from `ReservoirBase`
- Some members now common for `ReservoirBase` so simple refactored all `DefaultXXXReservoir`
- Added new test that check fix this problem


### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
