### PR TITLE
Update EnvironmentInfoProviderCache.cs to prevent NullReferenceException in NetFx 4.6.2

### DIFF
--- a/src/Core/src/App.Metrics.Core/Infrastructure/EnvironmentInfoProviderCache.cs
+++ b/src/Core/src/App.Metrics.Core/Infrastructure/EnvironmentInfoProviderCache.cs
@@ -139,7 +139,10 @@ namespace App.Metrics.Infrastructure
         }
 #else
         // ReSharper disable InconsistentNaming
-        private static string GetFrameworkDescription() { return AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName; }
+        private static string GetFrameworkDescription() {     
+            var attribute = (TargetFrameworkAttribute)Assembly.GetEntryAssembly()?.GetCustomAttribute(typeof(TargetFrameworkAttribute));
+            return attribute?.FrameworkName ?? "Unknown Framework"; 
+        }
         // ReSharper restore InconsistentNaming
 #endif
     }


### PR DESCRIPTION
NullReferenceException is thrown by the code that determines the framework description for non netstandard. Proposed is the code change to fix this.

Thanks for helping out :+1:

Before submitting a pull request, please have a quick read through the [contribution guidelines](https://github.com/AppMetrics/AppMetrics/blob/main/.github/CONTRIBUTING.md) and provide the following information, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- link to the issue/feature using its github issue number #number (if an issue/feature does not exist, please create it first)

### Details on the issue fix or feature implementation

- provide some details here


### Confirm the following

- [ ] I have ensured that I have merged the latest changes from the dev branch
- [ ] I have successfully run a [local build](https://github.com/AppMetrics/AppMetrics#how-to-build)
- [ ] I have included unit tests for the issue/feature
- [ ] I have included the github issue number in my commits
